### PR TITLE
Simplify and fix ping response, add build info during build time

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,21 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d76f06183572b1eabc33c586fae00b16430091ca48300ec9fdc8450f88df4c35"
+  name = "github.com/bloomberg/goldpinger"
+  packages = [
+    "pkg/client",
+    "pkg/client/operations",
+    "pkg/goldpinger",
+    "pkg/models",
+    "pkg/restapi",
+    "pkg/restapi/operations",
+  ]
+  pruneopts = "UT"
+  revision = "0ebc4eecfa001237308b3c148619ec0f22f21ea1"
+
+[[projects]]
   digest = "1:6f82cacd0af5921e99bf3f46748705239b36489464f4529a1589bc895764fb18"
   name = "github.com/docker/go-units"
   packages = ["."]
@@ -612,6 +627,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/bloomberg/goldpinger/pkg/client",
+    "github.com/bloomberg/goldpinger/pkg/client/operations",
+    "github.com/bloomberg/goldpinger/pkg/goldpinger",
+    "github.com/bloomberg/goldpinger/pkg/models",
+    "github.com/bloomberg/goldpinger/pkg/restapi",
+    "github.com/bloomberg/goldpinger/pkg/restapi/operations",
     "github.com/go-openapi/errors",
     "github.com/go-openapi/loads",
     "github.com/go-openapi/runtime",
@@ -630,6 +651,7 @@
     "golang.org/x/net/netutil",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
   ]
   solver-name = "gps-cdcl"

--- a/build/build.sh
+++ b/build/build.sh
@@ -37,5 +37,6 @@ export CGO_ENABLED=0
 export GOARCH="${ARCH}"
 
 go build \
-   -o ./bin/${BIN} \
-   ./cmd/${BIN}
+    -ldflags "-X 'main.Version=${VERSION}' -X 'main.Build=`date`'" \
+    -o ./bin/${BIN} \
+    ./cmd/${BIN}

--- a/cmd/goldpinger/main.go
+++ b/cmd/goldpinger/main.go
@@ -29,7 +29,15 @@ import (
 	flags "github.com/jessevdk/go-flags"
 )
 
+// these will be injected during build in build.sh script to allow printing
+var (
+	Version, Build string
+)
+
 func main() {
+
+	log.Println("Goldpinger version:", Version, "build:", Build)
+
 	// load embedded swagger file
 	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
 	if err != nil {

--- a/pkg/goldpinger/stats.go
+++ b/pkg/goldpinger/stats.go
@@ -83,19 +83,6 @@ var (
 		},
 	)
 
-	groups = map[string]map[string]int64{
-		"received": map[string]int64{
-			"ping":      0,
-			"check":     0,
-			"check_all": 0,
-		},
-		"made": map[string]int64{
-			"ping":      0,
-			"check":     0,
-			"check_all": 0,
-		},
-	}
-
 	bootTime = time.Now()
 )
 
@@ -109,21 +96,14 @@ func init() {
 }
 
 func GetStats() *models.PingResults {
-	var result models.PingResults
-	var calls models.CallStats
-
-	calls.Check = groups["received"]["check"]
-	calls.CheckAll = groups["received"]["check_all"]
-	calls.Ping = groups["received"]["ping"]
-	result.BootTime = strfmt.DateTime(bootTime)
-	result.Received = &calls
-	return &result
+	// GetStats no longer populates the received and made calls - use metrics for that instead
+	return &models.PingResults{
+		BootTime: strfmt.DateTime(bootTime),
+	}
 }
 
 // counts various calls received and made
 func CountCall(group string, call string) {
-	groups[group][call]++
-
 	goldpingerStatsCounter.WithLabelValues(
 		GoldpingerConfig.Hostname,
 		group,


### PR DESCRIPTION
There is no longer need to return the manually counted metrics in the ping response, since metrics are covering that. Plus, that was not thread-safe.

I'm leaving the swagger spec as is for backwards compatibility.