### PR TITLE
Use a configuration value for the label selector when discovering goldpinger pods

### DIFF
--- a/pkg/goldpinger/config.go
+++ b/pkg/goldpinger/config.go
@@ -26,5 +26,6 @@ var GoldpingerConfig = struct {
 	Hostname         string `long:"hostname" description:"Hostname to use" env:"HOSTNAME"`
 	Port             int    `long:"client-port-override" description:"(for testing) use this port when calling other instances" env:"CLIENT_PORT_OVERRIDE"`
 	UseHostIP        bool   `long:"use-host-ip" description:"When making the calls, use host ip (defaults to pod ip)" env:"USE_HOST_IP"`
+	LabelSelector    string `long:"label-selector" description:"label selector to use to discover goldpinger pods in the cluster" env:"LABEL_SELECTOR" default:"app=goldpinger"`
 	KubernetesClient *kubernetes.Clientset
 }{}

--- a/pkg/goldpinger/k8s.go
+++ b/pkg/goldpinger/k8s.go
@@ -20,10 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GetAllPods returns a map of Pod IP to Host IP based on a label selector defined in config
 func GetAllPods() map[string]string {
 
 	timer := GetLabeledKubernetesCallsTimer()
-	pods, err := GoldpingerConfig.KubernetesClient.CoreV1().Pods("").List(metav1.ListOptions{LabelSelector: "app=goldpinger"})
+	pods, err := GoldpingerConfig.KubernetesClient.CoreV1().Pods("").List(metav1.ListOptions{LabelSelector: GoldpingerConfig.LabelSelector})
 	if err != nil {
 		log.Println("Error getting pods for selector: ", err.Error())
 		CountError("kubernetes_api")

--- a/pkg/goldpinger/k8s.go
+++ b/pkg/goldpinger/k8s.go
@@ -33,7 +33,7 @@ func getNamespace() string {
 // GetAllPods returns a map of Pod IP to Host IP based on a label selector defined in config
 func GetAllPods() map[string]string {
 	timer := GetLabeledKubernetesCallsTimer()
-	pods, err := GoldpingerConfig.KubernetesClient.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: GoldpingerConfig.LabelSelector})
+	pods, err := GoldpingerConfig.KubernetesClient.CoreV1().Pods(getNamespace()).List(metav1.ListOptions{LabelSelector: GoldpingerConfig.LabelSelector})
 	if err != nil {
 		log.Println("Error getting pods for selector: ", err.Error())
 		CountError("kubernetes_api")


### PR DESCRIPTION
This allows an operator to set the `LABEL_SELECTOR` environment variable to configure discovery of goldpinger Pods