### PR TITLE
fix Dockerfile to build from current workspace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 .git/
 /vendor/
-/bin/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+/vendor/
+/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,15 @@ FROM golang:1.11-alpine as builder
 RUN apk add --update git make bash
 RUN go get -u github.com/golang/dep/cmd/dep
 
-# Get sources
+# Get sources and dependencies
 
-RUN go get github.com/bloomberg/goldpinger/cmd/goldpinger
 WORKDIR /go/src/github.com/bloomberg/goldpinger
-
-# Install our dependencies
-
+COPY Gopkg.toml Gopkg.lock Makefile ./
 RUN make vendor
 
 # Build goldpinger
 
+COPY . ./
 RUN make bin/goldpinger
 
 # Build the asset container, copy over goldpinger

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.11-alpine as builder
 RUN apk add --update git make bash
 RUN go get -u github.com/golang/dep/cmd/dep
 
-# Get sources and dependencies
+# Get dependencies
 
 WORKDIR /go/src/github.com/bloomberg/goldpinger
 COPY Gopkg.toml Gopkg.lock Makefile ./

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 
 vendor:
 	rm -rf ./vendor
-	dep ensure -v
+	dep ensure -v -vendor-only
 
 swagger:
 	swagger generate server -t pkg -f ./swagger.yml --exclude-main -A goldpinger && \


### PR DESCRIPTION
*why?*

The current Dockerfile fetches source code using `go get` which will always download `master` branch by default. 
It's probably not what you intended when building from specific git tag/sha.