### PR TITLE
Fix GOOS problems during simple docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - make clean && make vendor && make && ./bin/goldpinger --help
   
   # build an image and run the image
-  - make clean && make build
+  - make clean && make vendor && make build
   - docker images
   - docker run `make version` --help
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,18 @@ go:
 
 script:
   - docker --version
-  - go get -u github.com/golang/dep/cmd/dep && make vendor && make && make build
+  # dep
+  - go get -u github.com/golang/dep/cmd/dep
+  
+  # build locally and run locally
+  - make clean && make vendor && make && ./bin/goldpinger --help
+  
+  # build an image and run the image
+  - make clean && make build
   - docker images
-  - make build-multistage
+  - docker run `make version` --help
+  
+  # build an image using the multistage builder
+  - make clean && make build-multistage
   - docker images
+  - docker run `make version` --help

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ version ?= 1.1.0
 bin ?= goldpinger
 pkg ?= "github.com/bloomberg/goldpinger"
 tag = $(name):$(version)
+goos ?= ${GOOS}
 namespace ?= ""
 files = $(shell find . -iname "*.go")
 
 
 bin/$(bin): $(files)
-	PKG=${pkg} ARCH=amd64 VERSION=${version} BIN=${bin} ./build/build.sh
+	GOOS=${goos} PKG=${pkg} ARCH=amd64 VERSION=${version} BIN=${bin} ./build/build.sh
 
 clean:
 	rm -rf ./vendor
@@ -25,6 +26,7 @@ swagger:
 build-multistage:
 	docker build -t $(tag) -f ./Dockerfile .
 
+build: GOOS=linux
 build: bin/$(bin)
 	docker build -t $(tag) -f ./build/Dockerfile-simple .
 

--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,8 @@ push:
 
 run:
 	go run ./cmd/goldpinger/main.go
+	
+version:
+	@echo $(tag)
 
-.PHONY: clean vendor build-swagger build tag push run
+.PHONY: clean vendor swagger build build-multistage tag push run version

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,10 +35,7 @@ fi
 
 export CGO_ENABLED=0
 export GOARCH="${ARCH}"
-GOOS=${GOOS:-}
-if [ ! -z "${GOOS}" ]; then
-    export GOOS
-fi
+export GOOS=${GOOS:-}
 
 go build \
     -ldflags "-X 'main.Version=${VERSION}' -X 'main.Build=`date`'" \

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,6 +35,10 @@ fi
 
 export CGO_ENABLED=0
 export GOARCH="${ARCH}"
+GOOS=${GOOS:-}
+if [ ! -z "${GOOS}" ]; then
+    export GOOS
+fi
 
 go build \
     -ldflags "-X 'main.Version=${VERSION}' -X 'main.Build=`date`'" \


### PR DESCRIPTION
Fixes #17 

In this PR:
- Added a possibility to pass `GOOS` to `build.sh` (as an environment variable);
- Changed `make build` workflow to:
    - Remove previous binary (the name of binary is hardcoded, because it's also hardcoded in `Dockerfile-simple`);
    - Compile a new binary with `GOOS=linux`;
    - Run docker build.