### PR TITLE
More complete example-serviceaccounts.yml, now with rbac rules

### DIFF
--- a/extras/example-serviceaccounts.yml
+++ b/extras/example-serviceaccounts.yml
@@ -1,21 +1,31 @@
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: goldpinger-serviceaccount
+  namespace: default
+
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: goldpinger
+  namespace: default
+  labels:
+    app: goldpinger
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
       app: goldpinger
-      version: "1.0.0"
   template:
     metadata:
       labels:
         app: goldpinger
-        version: "1.0.0"
     spec:
+      serviceAccount: "goldpinger-serviceaccount"
       containers:
         - name: goldpinger
           env:
@@ -28,7 +38,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: "docker.io/mynamespace-replaceme/goldpinger:1.0.0"
+          image: "docker.io/mynamespace-replaceme/goldpinger:1.1.0"
           ports:
             - containerPort: 80
               name: http
@@ -37,6 +47,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: goldpinger
+  namespace: default
   labels:
     app: goldpinger
 spec:
@@ -47,3 +58,30 @@ spec:
       name: http
   selector:
     app: goldpinger
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goldpinger-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: goldpinger-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: goldpinger-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: goldpinger-serviceaccount
+    namespace: default
+


### PR DESCRIPTION
Here is a better version of https://github.com/bloomberg/goldpinger/blob/master/extras/example-serviceaccounts.yml

I just can't make it turn key because of https://github.com/bloomberg/goldpinger/issues/27

other than that, one can simply `kubectl apply -f example-serviceaccounts.yml` and have goldpinger running out of the box.

To remove it, one should type `kubectl delete -f example-serviceaccounts.yml`
