### PR TITLE
Enable push of images to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,8 @@ script:
   - make clean && make build-multistage
   - docker images
   - docker run `make version` --help
+
+after_success:
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+      docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD" && make tag && make push;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,7 @@ script:
 deploy:
   provider: script
   script: bash docker_deploy.sh
+  skip_cleanup: true
   on:
-    branch: master
+    tags: true
+    condition: -n "$DOCKER_PASSWORD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ script:
   - docker images
   - docker run `make version` --help
 
-after_success:
-  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-      docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD" && make tag && make push;
-    fi
+deploy:
+  provider: script
+  script: bash docker_deploy.sh
+  on:
+    branch: master

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ bin ?= goldpinger
 pkg ?= "github.com/bloomberg/goldpinger"
 tag = $(name):$(version)
 goos ?= ${GOOS}
-namespace ?= ""
+namespace ?= "bloomberg/"
 files = $(shell find . -iname "*.go")
 
 
@@ -38,7 +38,7 @@ push:
 
 run:
 	go run ./cmd/goldpinger/main.go
-	
+
 version:
 	@echo $(tag)
 

--- a/docker_deploy.sh
+++ b/docker_deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD" && make tag && make push
+


### PR DESCRIPTION
This patch will enable pushes of any successful builds (using Travis-CI)
of the 'master' branch to the proper repository on DockerHub. The credentials
necessary are provided via environment variables configured in the
Travis-CI settings.

Addresses issue #27

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>