### PR TITLE
prometheus service auto-discovery  

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ kind: Service
 metadata:
   name: goldpinger
   namespace: default
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8080'
   labels:
     app: goldpinger
 spec:

--- a/README.md
+++ b/README.md
@@ -134,10 +134,16 @@ spec:
       app: goldpinger
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8080'
       labels:
         app: goldpinger
     spec:
       serviceAccount: "goldpinger-serviceaccount"
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -191,9 +197,6 @@ kind: Service
 metadata:
   name: goldpinger
   namespace: default
-  annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '8080'
   labels:
     app: goldpinger
 spec:


### PR DESCRIPTION
*#1*

**Describe your changes**
goldPinger expose prometheus metrics at ip:port/metrics, and you need to send it to prometheus or add configuration to prometheus in order to fetch, but if this request merged, you will allow prometheus to auto-discover your metrics and fetch it from service-name:ip/metrics 

**Testing performed**
I add this and checked from prometheus side if target is up and metrics fetched.

**Additional context**
Add any other context about your contribution here.
