### PR TITLE
Fix a Goldpinger reporting healthy when kubernetes returns an empty IP field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 name ?= goldpinger
-version ?= 2.0.0
+version ?= 2.0.1
 bin ?= goldpinger
 pkg ?= "github.com/bloomberg/goldpinger"
 tag = $(name):$(version)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          image: "docker.io/bloomberg/goldpinger:2.0.0"
+          image: "docker.io/bloomberg/goldpinger:2.0.1"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/pkg/goldpinger/client.go
+++ b/pkg/goldpinger/client.go
@@ -98,6 +98,7 @@ func PingAllPods(pods map[string]string) *models.CheckResults {
 
 			if err != nil {
 				channelResult.podResult = models.PodResult{HostIP: channelResult.hostIPv4, OK: &OK, Error: err.Error(), StatusCode: 500, ResponseTimeMs: responseTime}
+				channelResult.podIP = hostIP
 				CountError("ping")
 			} else {
 				resp, err := client.Operations.Ping(nil)
@@ -174,6 +175,7 @@ func CheckAllPods(pods map[string]string) *models.CheckAllResults {
 					HostIP: channelResult.hostIPv4,
 					Error:  err.Error(),
 				}
+				channelResult.podIP = hostIP
 				CountError("checkAll")
 			} else {
 				resp, err := client.Operations.CheckServicePods(nil)

--- a/pkg/goldpinger/client.go
+++ b/pkg/goldpinger/client.go
@@ -88,13 +88,13 @@ func PingAllPods(pods map[string]string) *models.CheckResults {
 			resp, err := getClient(pickPodHostIP(podIP, hostIP)).Operations.Ping(nil)
 
 			channelResult.hostIPv4.UnmarshalText([]byte(hostIP))
+			responseTime := time.Since(start).Nanoseconds() / int64(time.Millisecond)
 			var OK = (err == nil)
 			if OK {
-				responseTime := time.Since(start).Nanoseconds() / int64(time.Millisecond)
 				channelResult.podResult = models.PodResult{HostIP: channelResult.hostIPv4, OK: &OK, Response: resp.Payload, StatusCode: 200, ResponseTimeMs: responseTime}
 				timer.ObserveDuration()
 			} else {
-				channelResult.podResult = models.PodResult{HostIP: channelResult.hostIPv4, OK: &OK, Error: err.Error(), StatusCode: 500}
+				channelResult.podResult = models.PodResult{HostIP: channelResult.hostIPv4, OK: &OK, Error: err.Error(), StatusCode: 500, ResponseTimeMs: responseTime}
 				CountError("ping")
 			}
 			channelResult.podIP = podIP

--- a/pkg/goldpinger/client.go
+++ b/pkg/goldpinger/client.go
@@ -53,8 +53,8 @@ func pickPodHostIP(podIP, hostIP string) string {
 
 func checkDNS() *models.DNSResults {
 	results := models.DNSResults{}
-	for _, host := range GoldpingerConfig.DnsHosts{
-		
+	for _, host := range GoldpingerConfig.DnsHosts {
+
 		var dnsResult models.DNSResult
 
 		start := time.Now()
@@ -185,7 +185,7 @@ func CheckAllPods(pods map[string]string) *models.CheckAllResults {
 			PodIP:  podIPv4,
 		})
 		if response.checkAllPodResult.Response != nil &&
-		   response.checkAllPodResult.Response.DNSResults != nil {
+			response.checkAllPodResult.Response.DNSResults != nil {
 			if result.DNSResults == nil {
 				result.DNSResults = make(map[string]models.DNSResults)
 			}


### PR DESCRIPTION
If you run into a situation where kubernetes returns one of the goldpinger nodes without an IP (say, for example, that docker went rogue and is stuck trying to start the pod):

```sh
$ kubectl get pods | grep goldpinger
goldpinger-2n2lc                1/1     Running     0          18m   10.244.50.82    my-cluster-master-2   <none>           <none>
goldpinger-9jg79                1/1     Running     0          23m   10.244.68.120   my-cluster-worker-1   <none>           <none>
goldpinger-hvk6q                0/1     Completed   0          37m   <none>          my-cluster-worker-0   <none>           <none>
goldpinger-l4hkl                1/1     Running     0          18m   10.244.34.82    my-cluster-master-1   <none>           <none>
goldpinger-vspx7                1/1     Running     0          20m   10.244.91.82    my-cluster-master-0   <none>           <none>
```

Kubernetes will continue returning that pod, with the pod IP set to an empty value.

Unfortunately, that is not handled by goldpinger, which results in calling `:<port>`, and calling itself. It then happily reports the affected pod as healthy:

```js
{
  "dnsResults": {
    "google.com": {
      "response-time-ms": 9
    }
  },
  "podResults": {
    "": {
      "HostIP": "192.168.0.193",
      "OK": true,
      "response": {
        "boot_time": "2020-03-11T11:53:12.578Z"
      },
      "status-code": 200
    },
    "10.244.34.82": {
      "HostIP": "192.168.5.63",
      "OK": true,
      "response": {
        "boot_time": "2020-03-11T11:57:47.369Z"
      },
      "status-code": 200
    },
    (...)
  }
}
```

**Describe your changes**
I added an error for when there is no IP to be called. I also changed the error return code to 504, when the call fails, and 500 when can't call because of lacking IP.
