### PR TITLE
Customize timeouts

### DIFF
--- a/pkg/goldpinger/config.go
+++ b/pkg/goldpinger/config.go
@@ -33,4 +33,9 @@ var GoldpingerConfig = struct {
 	KubernetesClient *kubernetes.Clientset
 
 	DnsHosts []string `long:"host-to-resolve" description:"A host to attempt dns resolve on (space delimited)" env:"HOSTS_TO_RESOLVE" env-delim:" "`
+
+	// Timeouts
+	PingTimeoutMs     int64 `long:"ping-timeout-ms" description:"The timeout in milliseconds for a ping call to other goldpinger pods" env:"PING_TIMEOUT_MS" default:"300"`
+	CheckTimeoutMs    int64 `long:"check-timeout-ms" description:"The timeout in milliseconds for a check call to other goldpinger pods" env:"CHECK_TIMEOUT_MS" default:"1000"`
+	CheckAllTimeoutMs int64 `long:"check-all-timeout-ms" description:"The timeout in milliseconds for a check-all call to other goldpinger pods" env:"CHECK_ALL_TIMEOUT_MS" default:"5000"`
 }{}

--- a/pkg/goldpinger/heatmap.go
+++ b/pkg/goldpinger/heatmap.go
@@ -18,6 +18,7 @@ package goldpinger
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"image"
 	"image/color"
@@ -26,6 +27,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"time"
 
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/basicfont"
@@ -79,8 +81,14 @@ func HeatmapHandler(w http.ResponseWriter, r *http.Request) {
 	// parse the query to set the parameters
 	query := r.URL.Query()
 
+	ctx, cancel := context.WithTimeout(
+		r.Context(),
+		time.Duration(GoldpingerConfig.CheckAllTimeoutMs)*time.Millisecond,
+	)
+	defer cancel()
+
 	// get the results
-	checkResults := CheckAllPods(GetAllPods())
+	checkResults := CheckAllPods(ctx, GetAllPods())
 
 	// set some sizes
 	numberOfPods := len(checkResults.Responses)

--- a/pkg/goldpinger/stats.go
+++ b/pkg/goldpinger/stats.go
@@ -15,6 +15,7 @@
 package goldpinger
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -106,7 +107,7 @@ func init() {
 	log.Println("Metrics setup - see /metrics")
 }
 
-func GetStats() *models.PingResults {
+func GetStats(ctx context.Context) *models.PingResults {
 	// GetStats no longer populates the received and made calls - use metrics for that instead
 	return &models.PingResults{
 		BootTime: strfmt.DateTime(bootTime),

--- a/static/index.html
+++ b/static/index.html
@@ -248,15 +248,19 @@ var main = function(timeout){
                 var edges = [];
                 var resp = data.responses;
                 for (let callId in resp) {
-                        var call = resp[callId].response['podResults'];
-                        if (typeof call !== 'string'){
-                                for (let target in call) {
-                                        edges.push({
-                                                source: callId,
-                                                target: target,
-                                                _data: call[target]
-                                        });
-                                };
+                        // If there was an error, the response can be undefined,
+                        // especially if there was a timeout/context exceeded
+                        if (resp[callId].response !== undefined) {
+                                var call = resp[callId].response['podResults'];
+                                if (typeof call !== 'string'){
+                                        for (let target in call) {
+                                                edges.push({
+                                                        source: callId,
+                                                        target: target,
+                                                        _data: call[target]
+                                                });
+                                        };
+                                }
                         }
                 };
 
@@ -480,6 +484,3 @@ $("#update-heatmap").click(function (e) {
 </script>
 </body>
 </html>
-
-
-


### PR DESCRIPTION
**Describe your changes**

We recently had an issue where flannel wasn't working on a given node and the UI was completely unhelpful in helping figure out which node was down:

<img width="1677" alt="Screen Shot 2020-04-06 at 8 27 24 PM" src="https://user-images.githubusercontent.com/297368/78617735-40e4c600-7846-11ea-8d63-7cf0da492353.png">

This is a [known issue](https://github.com/bloomberg/goldpinger/issues/67) and the [proposed fix](https://github.com/bloomberg/goldpinger/pull/68) doesn't quite work

Investigating further, we noticed that the `/check_all` endpoint also failed to produce useful results:

```json
{
  ...
  "responses": {
    "198.18.0.64": {
      "HostIP": "<redacted>",
      "OK": false,
      "error": "Get \"http://198.18.0.64:80/check\": context deadline exceeded"
    },
    "198.18.1.7": {
      "HostIP": "<redacted>",
      "OK": false,
      "error": "Get \"http://198.18.1.7:80/check\": context deadline exceeded"
    },
    "198.18.2.6": {
      "HostIP": "<redacted>",
      "OK": false,
      "error": "Get \"http://198.18.2.6:80/check\": context deadline exceeded"
    },
    "198.18.3.6": {
      "HostIP": "<redacted>",
      "OK": false,
      "error": "Get \"http://198.18.3.6:80/check\": context deadline exceeded"
    },
    "198.18.4.7": {
      "HostIP": "10.34.8.98",
      "OK": false,
      "error": "Get \"http://198.18.4.7:80/check\": context deadline exceeded"
    }
  }
}
```

The underlying cause is that `/check_all` calls the `/check` endpoint on all the goldpinger pods which calls the `/ping` endpoint on all the pods **AND** all the calls use the [same default timeout](https://github.com/go-openapi/runtime/blob/4740fbe020aef20dd0806dc3c2074bb5b814f29e/client/runtime.go#L213-L214) of 30 seconds. Which means that by the time the `/ping` endpoint times out on any given node, the `/check` endpoint also times out and is not able to return any interesting results.

This PR fixes things by allowing you to specify a custom timeout for all the three calls - `/check_all`, `/check`, and `/ping`

**Testing performed**

If you use `flannel`, this is easy to test with a simple iptables rule that blocks all traffic to flannel `sudo iptables -A INPUT -j DROP -p udp --destination-port 8472`. Other ways of testing might be to block/interfere with the cni on a given node. 

After deploying the goldpinger built from this branch, the `/check` and `/check_all` endpoints give exact info about which node is bad:

```json
{
   ...
   "goldpinger-zmrwq": {
      "HostIP": "<redacted>",
      "OK": true,
      "PodIP": "198.18.3.8",
      "response": {
        "dnsResults": {
         ...
        },
        "podResults": {
          "goldpinger-9ws9j": {
            "HostIP": "<redacted>",
            "OK": true,
            "PodIP": "198.18.0.68",
            "response": {
              "boot_time": "2020-04-07T01:06:17.093Z"
            },
            "response-time-ms": 1,
            "status-code": 200
          },
          "goldpinger-kdzsk": {
            "HostIP": "<redacted>",
            "OK": true,
            "PodIP": "198.18.4.9",
            "response": {
              "boot_time": "2020-04-07T01:06:15.889Z"
            },
            "status-code": 200
          },
          "goldpinger-rx5zw": {
            "HostIP": "<redacted>",
            "OK": true,
            "PodIP": "198.18.1.10",
            "response": {
              "boot_time": "2020-04-07T01:06:15.894Z"
            },
            "status-code": 200
          },
          "goldpinger-zmrwq": {
            "HostIP": "<redacted>",
            "OK": true,
            "PodIP": "198.18.3.8",
            "response": {
              "boot_time": "2020-04-07T01:06:16.774Z"
            },
            "status-code": 200
          },
          "goldpinger-zs5hw": {
            "HostIP": "<redacted>",
            "OK": false,
            "PodIP": "198.18.2.8",
            "error": "Get \"http://198.18.2.8:80/ping\": context deadline exceeded",
            "response-time-ms": 300,
            "status-code": 504
          }
        }
      }
    },
    ...
}
```

And the UI still works as expected:

<img width="1038" alt="Screen Shot 2020-04-06 at 8 28 07 PM" src="https://user-images.githubusercontent.com/297368/78619264-dbdf9f00-784a-11ea-90a4-8ba642d23438.png">

Closes #67 