### PR TITLE
Calm the thundering herd

### DIFF
--- a/pkg/goldpinger/client.go
+++ b/pkg/goldpinger/client.go
@@ -33,7 +33,19 @@ import (
 // CheckNeighbours queries the kubernetes API server for all other goldpinger pods
 // then calls Ping() on each one
 func CheckNeighbours(ctx context.Context) *models.CheckResults {
-	return PingAllPods(ctx, SelectPods())
+	// Mux to prevent concurrent map address
+	checkResultsMux.Lock()
+	defer checkResultsMux.Unlock()
+
+	final := models.CheckResults{}
+	final.PodResults = make(map[string]models.PodResult)
+	for podName, podResult := range checkResults.PodResults {
+		final.PodResults[podName] = podResult
+	}
+	if len(GoldpingerConfig.DnsHosts) > 0 {
+		final.DNSResults = *checkDNS()
+	}
+	return &final
 }
 
 // CheckNeighboursNeighbours queries the kubernetes API server for all other goldpinger
@@ -71,114 +83,6 @@ func checkDNS() *models.DNSResults {
 		results[host] = dnsResult
 	}
 	return &results
-}
-
-func PingAllPods(pingAllCtx context.Context, pods map[string]*GoldpingerPod) *models.CheckResults {
-
-	result := models.CheckResults{}
-
-	ch := make(chan PingAllPodsResult, len(pods))
-	wg := sync.WaitGroup{}
-	wg.Add(len(pods))
-
-	for _, pod := range pods {
-
-		go func(pod *GoldpingerPod) {
-
-			logger := zap.L().With(
-				zap.String("op", "ping"),
-				zap.String("name", pod.Name),
-				zap.String("hostIP", pod.HostIP),
-				zap.String("podIP", pod.PodIP),
-			)
-
-			// metrics
-			CountCall("made", "ping")
-			timer := GetLabeledPeersCallsTimer("ping", pod.HostIP, pod.PodIP)
-			start := time.Now()
-
-			// setup
-			channelResult := PingAllPodsResult{podName: pod.Name}
-			OK := false
-
-			var responseTime int64
-			var hostIPv4 strfmt.IPv4
-			var podIPv4 strfmt.IPv4
-
-			hostIPv4.UnmarshalText([]byte(pod.HostIP))
-			podIPv4.UnmarshalText([]byte(pod.PodIP))
-
-			client, err := getClient(pickPodHostIP(pod.PodIP, pod.HostIP))
-			if err != nil {
-				logger.Warn("Couldn't get a client for Ping", zap.Error(err))
-				channelResult.podResult = models.PodResult{
-					PodIP:          podIPv4,
-					HostIP:         hostIPv4,
-					OK:             &OK,
-					Error:          err.Error(),
-					StatusCode:     500,
-					ResponseTimeMs: responseTime,
-				}
-				CountError("ping")
-			} else {
-				pingCtx, cancel := context.WithTimeout(
-					pingAllCtx,
-					time.Duration(GoldpingerConfig.PingTimeoutMs)*time.Millisecond,
-				)
-				defer cancel()
-
-				params := operations.NewPingParamsWithContext(pingCtx)
-				resp, err := client.Operations.Ping(params)
-				responseTime = time.Since(start).Nanoseconds() / int64(time.Millisecond)
-				OK = (err == nil)
-				if OK {
-					logger.Debug("Pink Ok", zap.Int64("responseTime", responseTime))
-					channelResult.podResult = models.PodResult{
-						PodIP:          podIPv4,
-						HostIP:         hostIPv4,
-						OK:             &OK,
-						Response:       resp.Payload,
-						StatusCode:     200,
-						ResponseTimeMs: responseTime,
-					}
-					timer.ObserveDuration()
-				} else {
-					logger.Warn("Ping returned error", zap.Int64("responseTime", responseTime), zap.Error(err))
-					channelResult.podResult = models.PodResult{
-						PodIP:          podIPv4,
-						HostIP:         hostIPv4,
-						OK:             &OK,
-						Error:          err.Error(),
-						StatusCode:     504,
-						ResponseTimeMs: responseTime,
-					}
-					CountError("ping")
-				}
-			}
-
-			ch <- channelResult
-			wg.Done()
-		}(pod)
-	}
-	if len(GoldpingerConfig.DnsHosts) > 0 {
-		result.DNSResults = *checkDNS()
-	}
-	wg.Wait()
-	close(ch)
-
-	counterHealthy, counterUnhealthy := 0.0, 0.0
-
-	result.PodResults = make(map[string]models.PodResult)
-	for response := range ch {
-		if *response.podResult.OK {
-			counterHealthy++
-		} else {
-			counterUnhealthy++
-		}
-		result.PodResults[response.podName] = response.podResult
-	}
-	CountHealthyUnhealthyNodes(counterHealthy, counterUnhealthy)
-	return &result
 }
 
 type CheckServicePodsResult struct {

--- a/pkg/goldpinger/config.go
+++ b/pkg/goldpinger/config.go
@@ -23,6 +23,7 @@ var GoldpingerConfig = struct {
 	StaticFilePath   string `long:"static-file-path" description:"Folder for serving static files" env:"STATIC_FILE_PATH"`
 	KubeConfigPath   string `long:"kubeconfig" description:"Path to kubeconfig file" env:"KUBECONFIG"`
 	RefreshInterval  int    `long:"refresh-interval" description:"If > 0, will create a thread and collect stats every n seconds" env:"REFRESH_INTERVAL" default:"30"`
+	JitterFactor     float64 `long:"jitter-factor" description:"The amount of jitter to add while pinging clients" env:"JITTER_FACTOR" default:"0.05"`
 	Hostname         string `long:"hostname" description:"Hostname to use" env:"HOSTNAME"`
 	PodIP            string `long:"pod-ip" description:"Pod IP to use" env:"POD_IP"`
 	PodName          string `long:"pod-name" description:"The name of this pod - used to select --ping-number of pods using rendezvous hashing" env:"POD_NAME"`

--- a/pkg/goldpinger/pinger.go
+++ b/pkg/goldpinger/pinger.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package goldpinger
 
 import (
@@ -9,6 +23,7 @@ import (
 	apiclient "github.com/bloomberg/goldpinger/v3/pkg/client"
 	"github.com/bloomberg/goldpinger/v3/pkg/client/operations"
 	"github.com/bloomberg/goldpinger/v3/pkg/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -19,7 +34,8 @@ type Pinger struct {
 	client      *apiclient.Goldpinger
 	timeout     time.Duration
 	histogram   prometheus.Observer
-	result      PingAllPodsResult
+	hostIPv4    strfmt.IPv4
+	podIPv4     strfmt.IPv4
 	resultsChan chan<- PingAllPodsResult
 	stopChan    chan struct{}
 	logger      *zap.Logger
@@ -49,25 +65,48 @@ func NewPinger(pod *GoldpingerPod, resultsChan chan<- PingAllPodsResult) *Pinger
 		),
 	}
 
-	// Initialize the result
-	p.result.hostIPv4.UnmarshalText([]byte(pod.HostIP))
-	p.result.podIPv4.UnmarshalText([]byte(pod.PodIP))
+	// Initialize the host/pod IPv4
+	p.hostIPv4.UnmarshalText([]byte(pod.HostIP))
+	p.podIPv4.UnmarshalText([]byte(pod.PodIP))
 
-	// Get a client for pinging the given pod
-	// On error, create a static pod result that does nothing
-	client, err := getClient(pickPodHostIP(pod.PodIP, pod.HostIP))
-	if err == nil {
-		p.client = client
-	} else {
-		OK := false
-		p.client = nil
-		p.result.podResult = models.PodResult{HostIP: p.result.hostIPv4, OK: &OK, Error: err.Error(), StatusCode: 500, ResponseTimeMs: 0}
-	}
 	return &p
+}
+
+// getClient returns a client that can be used to ping the given pod
+// On error, it returns a static result
+func (p *Pinger) getClient() (*apiclient.Goldpinger, error) {
+	if p.client != nil {
+		return p.client, nil
+	}
+
+	client, err := getClient(pickPodHostIP(p.pod.PodIP, p.pod.HostIP))
+	if err != nil {
+		p.logger.Warn("Could not get client", zap.Error(err))
+		OK := false
+		p.resultsChan <- PingAllPodsResult{
+			podName: p.pod.Name,
+			podResult: models.PodResult{
+				PodIP:          p.podIPv4,
+				HostIP:         p.hostIPv4,
+				OK:             &OK,
+				Error:          err.Error(),
+				StatusCode:     500,
+				ResponseTimeMs: 0,
+			},
+		}
+		return nil, err
+	}
+	p.client = client
+	return p.client, nil
 }
 
 // Ping makes a single ping request to the given pod
 func (p *Pinger) Ping() {
+	client, err := p.getClient()
+	if err != nil {
+		return
+	}
+
 	CountCall("made", "ping")
 	start := time.Now()
 
@@ -75,39 +114,60 @@ func (p *Pinger) Ping() {
 	defer cancel()
 
 	params := operations.NewPingParamsWithContext(ctx)
-	resp, err := p.client.Operations.Ping(params)
+	resp, err := client.Operations.Ping(params)
 	responseTime := time.Since(start)
 	responseTimeMs := responseTime.Nanoseconds() / int64(time.Millisecond)
 	p.histogram.Observe(responseTime.Seconds())
 
 	OK := (err == nil)
 	if OK {
-		p.result.podResult = models.PodResult{
-			PodIP:          p.result.podIPv4,
-			HostIP:         p.result.hostIPv4,
-			OK:             &OK,
-			Response:       resp.Payload,
-			StatusCode:     200,
-			ResponseTimeMs: responseTimeMs,
+		p.resultsChan <- PingAllPodsResult{
+			podName: p.pod.Name,
+			podResult: models.PodResult{
+				PodIP:          p.podIPv4,
+				HostIP:         p.hostIPv4,
+				OK:             &OK,
+				Response:       resp.Payload,
+				StatusCode:     200,
+				ResponseTimeMs: responseTimeMs,
+			},
 		}
 		p.logger.Debug("Success pinging pod", zap.Duration("responseTime", responseTime))
 	} else {
-		p.result.podResult = models.PodResult{
-			PodIP:          p.result.podIPv4,
-			HostIP:         p.result.hostIPv4,
-			OK:             &OK,
-			Error:          err.Error(),
-			StatusCode:     504,
-			ResponseTimeMs: responseTimeMs,
+		p.resultsChan <- PingAllPodsResult{
+			podName: p.pod.Name,
+			podResult: models.PodResult{
+				PodIP:          p.podIPv4,
+				HostIP:         p.hostIPv4,
+				OK:             &OK,
+				Error:          err.Error(),
+				StatusCode:     504,
+				ResponseTimeMs: responseTimeMs,
+			},
 		}
 		p.logger.Warn("Ping returned error", zap.Duration("responseTime", responseTime), zap.Error(err))
 		CountError("ping")
 	}
-	p.resultsChan <- p.result
 }
 
 // PingContinuously continuously pings the given pod with a delay between
 // `period` and `period + jitterFactor * period`
-func (p *Pinger) PingContinuously(period time.Duration, jitterFactor float64) {
-	wait.JitterUntil(p.Ping, period, jitterFactor, false, p.stopChan)
+func (p *Pinger) PingContinuously(initialWait time.Duration, period time.Duration, jitterFactor float64) {
+	p.logger.Info(
+		"Starting pinger",
+		zap.Duration("period", period),
+		zap.Duration("initialWait", initialWait),
+		zap.Float64("jitterFactor", jitterFactor),
+	)
+
+	timer := time.NewTimer(initialWait)
+
+	select {
+	case <-timer.C:
+		wait.JitterUntil(p.Ping, period, jitterFactor, false, p.stopChan)
+	case <-p.stopChan:
+		// Do nothing
+	}
+	// We are done, send a message on the results channel to delete this
+	p.resultsChan <- PingAllPodsResult{podName: p.pod.Name, deleted: true}
 }

--- a/pkg/goldpinger/pinger.go
+++ b/pkg/goldpinger/pinger.go
@@ -86,6 +86,7 @@ func (p *Pinger) getClient() (*apiclient.Goldpinger, error) {
 		p.resultsChan <- PingAllPodsResult{
 			podName: p.pod.Name,
 			podResult: models.PodResult{
+				PingTime:       strfmt.DateTime(time.Now()),
 				PodIP:          p.podIPv4,
 				HostIP:         p.hostIPv4,
 				OK:             &OK,
@@ -124,6 +125,7 @@ func (p *Pinger) Ping() {
 		p.resultsChan <- PingAllPodsResult{
 			podName: p.pod.Name,
 			podResult: models.PodResult{
+				PingTime:       strfmt.DateTime(start),
 				PodIP:          p.podIPv4,
 				HostIP:         p.hostIPv4,
 				OK:             &OK,
@@ -137,6 +139,7 @@ func (p *Pinger) Ping() {
 		p.resultsChan <- PingAllPodsResult{
 			podName: p.pod.Name,
 			podResult: models.PodResult{
+				PingTime:       strfmt.DateTime(start),
 				PodIP:          p.podIPv4,
 				HostIP:         p.hostIPv4,
 				OK:             &OK,

--- a/pkg/goldpinger/pinger.go
+++ b/pkg/goldpinger/pinger.go
@@ -1,0 +1,86 @@
+package goldpinger
+
+import (
+	"log"
+	"time"
+
+	apiclient "github.com/bloomberg/goldpinger/pkg/client"
+	"github.com/bloomberg/goldpinger/pkg/models"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Pinger contains all the info needed by a goroutine to continuously ping a pod
+type Pinger struct {
+	podIP       string
+	hostIP      string
+	client      *apiclient.Goldpinger
+	timer       *prometheus.Timer
+	histogram   prometheus.Observer
+	result      PingAllPodsResult
+	resultsChan chan<- PingAllPodsResult
+	stopChan    chan struct{}
+}
+
+// NewPinger constructs and returns a Pinger object responsible for pinging a single
+// goldpinger pod
+func NewPinger(podIP string, hostIP string, resultsChan chan<- PingAllPodsResult) *Pinger {
+	p := Pinger{
+		podIP:       podIP,
+		hostIP:      hostIP,
+		resultsChan: resultsChan,
+		stopChan:    make(chan struct{}),
+
+		histogram: goldpingerResponseTimePeersHistogram.WithLabelValues(
+			GoldpingerConfig.Hostname,
+			"ping",
+			hostIP,
+			podIP,
+		),
+	}
+
+	// Initialize the result
+	p.result.hostIPv4.UnmarshalText([]byte(hostIP))
+	p.result.podIP = podIP
+
+	// Get a client for pinging the given pod
+	// On error, create a static pod result that does nothing
+	client, err := getClient(pickPodHostIP(podIP, hostIP))
+	if err == nil {
+		p.client = client
+	} else {
+		OK := false
+		p.client = nil
+		p.result.podResult = models.PodResult{HostIP: p.result.hostIPv4, OK: &OK, Error: err.Error(), StatusCode: 500, ResponseTimeMs: 0}
+		p.result.podIP = hostIP
+	}
+	return &p
+}
+
+// Ping makes a single ping request to the given pod
+func (p *Pinger) Ping() {
+	CountCall("made", "ping")
+	start := time.Now()
+
+	resp, err := p.client.Operations.Ping(nil)
+	responseTime := time.Since(start)
+	responseTimeMs := responseTime.Nanoseconds() / int64(time.Millisecond)
+	p.histogram.Observe(responseTime.Seconds())
+
+	OK := (err == nil)
+	if OK {
+		p.result.podResult = models.PodResult{HostIP: p.result.hostIPv4, OK: &OK, Response: resp.Payload, StatusCode: 200, ResponseTimeMs: responseTimeMs}
+		log.Printf("Success pinging pod: %s, host: %s, resp: %+v, response time: %+v", p.podIP, p.hostIP, resp.Payload, responseTime)
+	} else {
+		p.result.podResult = models.PodResult{HostIP: p.result.hostIPv4, OK: &OK, Error: err.Error(), StatusCode: 504, ResponseTimeMs: responseTimeMs}
+		log.Printf("Error pinging pod: %s, host: %s, err: %+v, response time: %+v", p.podIP, p.hostIP, err, responseTime)
+		CountError("ping")
+	}
+	p.resultsChan <- p.result
+}
+
+// PingContinuously continuously pings the given pod with a delay between
+// `period` and `period + jitterFactor * period`
+func (p *Pinger) PingContinuously(period time.Duration, jitterFactor float64) {
+	wait.JitterUntil(p.Ping, period, jitterFactor, false, p.stopChan)
+}

--- a/pkg/goldpinger/updater.go
+++ b/pkg/goldpinger/updater.go
@@ -18,9 +18,89 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"sync"
 
 	"go.uber.org/zap"
+
+	"github.com/bloomberg/goldpinger/pkg/models"
+	"github.com/go-openapi/strfmt"
 )
+
+// resultsMux controls access to the results from multiple goroutines
+var resultsMux sync.Mutex
+
+// getPingers creates a new set of pingers for the given pods
+// Each pinger is responsible for pinging a single pod and returns
+// the results on the results channel
+func getPingers(pods map[string]string, resultsChan chan<- PingAllPodsResult) map[string]*Pinger {
+	pingers := map[string]*Pinger{}
+
+	for podIP, hostIP := range pods {
+		pingers[podIP] = NewPinger(podIP, hostIP, resultsChan)
+	}
+	return pingers
+}
+
+// startPingers starts `n` goroutines to continuously ping all the given pods, one goroutine per pod
+// It staggers the start of all the go-routines to prevent a thundering herd
+func startPingers(pingers map[string]*Pinger) {
+	refreshPeriod := time.Duration(GoldpingerConfig.RefreshInterval) * time.Second
+	waitBetweenPods := refreshPeriod / time.Duration(len(pingers))
+
+	log.Printf("Refresh Period: %+v Wait Period: %+v Jitter Factor: %+v", refreshPeriod, waitBetweenPods, GoldpingerConfig.JitterFactor)
+
+	for _, p := range pingers {
+		go p.PingContinuously(refreshPeriod, GoldpingerConfig.JitterFactor)
+		time.Sleep(waitBetweenPods)
+	}
+}
+
+// collectResults simply reads results from the results channel and saves them in a map
+func collectResults(resultsChan <-chan PingAllPodsResult) *models.CheckResults {
+	results := models.CheckResults{}
+	results.PodResults = make(map[string]models.PodResult)
+	go func() {
+		for response := range resultsChan {
+			var podIPv4 strfmt.IPv4
+			podIPv4.UnmarshalText([]byte(response.podIP))
+
+			// results.PodResults map will be read by processResults()
+			// to count the number of healthy and unhealthy nodes
+			// Since concurrent access to maps isn't safe from multiple
+			// goroutines, lock the mutex before update
+			resultsMux.Lock()
+			results.PodResults[response.podIP] = response.podResult
+			resultsMux.Unlock()
+		}
+	}()
+	return &results
+}
+
+// processResults goes through all the entries in the results channel and counts
+// the number of health and unhealth nodes. It just reports the correct number
+func processResults(results *models.CheckResults) {
+	for {
+		var troublemakers []string
+		var counterHealthy, counterUnhealthy float64
+
+		resultsMux.Lock()
+		for podIP, value := range results.PodResults {
+			if *value.OK != true {
+				counterUnhealthy++
+				troublemakers = append(troublemakers, fmt.Sprintf("%s (%s)", podIP, value.HostIP.String()))
+			} else {
+				counterHealthy++
+			}
+		}
+		resultsMux.Unlock()
+
+		CountHealthyUnhealthyNodes(counterHealthy, counterUnhealthy)
+		if len(troublemakers) > 0 {
+			log.Println("Updater ran into trouble with these peers: ", troublemakers)
+		}
+		time.Sleep(time.Duration(GoldpingerConfig.RefreshInterval) * time.Second)
+	}
+}
 
 func StartUpdater() {
 	if GoldpingerConfig.RefreshInterval <= 0 {
@@ -28,26 +108,14 @@ func StartUpdater() {
 		return
 	}
 
-	updateInterval := time.Duration(GoldpingerConfig.RefreshInterval) * time.Second
+	pods := GoldpingerConfig.PodSelecter.SelectPods()
+	zap.S().Infof("Got Pods: %+v", pods)
 
-	// start the updater
-	go func() {
-		for {
-			ctx, cancel := context.WithTimeout(context.Background(), updateInterval)
+	// Create a channel for the results
+	resultsChan := make(chan PingAllPodsResult, len(pods))
+	pingers := getPingers(pods, resultsChan)
 
-			results := PingAllPods(ctx, SelectPods())
-			var troublemakers []string
-			for podIP, value := range results.PodResults {
-				if *value.OK != true {
-					troublemakers = append(troublemakers, fmt.Sprintf("%s (%s)", podIP, value.HostIP.String()))
-				}
-			}
-			if len(troublemakers) > 0 {
-				zap.L().Warn("Updater ran into trouble with these peers", zap.Strings("troublemakers", troublemakers))
-			}
-
-			cancel()
-			time.Sleep(updateInterval)
-		}
-	}()
+	startPingers(pingers)
+	results := collectResults(resultsChan)
+	go processResults(results)
 }

--- a/pkg/goldpinger/updater.go
+++ b/pkg/goldpinger/updater.go
@@ -182,6 +182,7 @@ func updateCounters(podName string, result *models.PodResult) {
 // collectResults simply reads results from the results channel and saves them in a map
 func collectResults(resultsChan <-chan PingAllPodsResult) {
 	for response := range resultsChan {
+		checkResultsMux.Lock()
 		if response.deleted {
 			updateCounters(response.podName, nil)
 			delete(checkResults.PodResults, response.podName)
@@ -190,6 +191,7 @@ func collectResults(resultsChan <-chan PingAllPodsResult) {
 			updateCounters(response.podName, &result)
 			checkResults.PodResults[response.podName] = result
 		}
+		checkResultsMux.Unlock()
 	}
 }
 

--- a/pkg/models/pod_result.go
+++ b/pkg/models/pod_result.go
@@ -24,6 +24,10 @@ type PodResult struct {
 	// o k
 	OK *bool `json:"OK,omitempty"`
 
+	// ping time
+	// Format: date-time
+	PingTime strfmt.DateTime `json:"PingTime,omitempty"`
+
 	// pod IP
 	// Format: ipv4
 	PodIP strfmt.IPv4 `json:"PodIP,omitempty"`
@@ -49,6 +53,10 @@ func (m *PodResult) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validatePingTime(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validatePodIP(formats); err != nil {
 		res = append(res, err)
 	}
@@ -70,6 +78,19 @@ func (m *PodResult) validateHostIP(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("HostIP", "body", "ipv4", m.HostIP.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *PodResult) validatePingTime(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.PingTime) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("PingTime", "body", "date-time", m.PingTime.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/restapi/embedded_spec.go
+++ b/pkg/restapi/embedded_spec.go
@@ -259,6 +259,10 @@ func init() {
           "type": "boolean",
           "default": false
         },
+        "PingTime": {
+          "type": "string",
+          "format": "date-time"
+        },
         "PodIP": {
           "type": "string",
           "format": "ipv4"
@@ -526,6 +530,10 @@ func init() {
         "OK": {
           "type": "boolean",
           "default": false
+        },
+        "PingTime": {
+          "type": "string",
+          "format": "date-time"
         },
         "PodIP": {
           "type": "string",

--- a/swagger.yml
+++ b/swagger.yml
@@ -37,6 +37,9 @@ definitions:
       OK:
         type: boolean
         default: false
+      PingTime:
+        format: date-time
+        type: string
       PodIP:
         type: string
         format: ipv4


### PR DESCRIPTION
# Describe your changes

## The problem

We recently added alerts for more than 30% of our goldpinger pods taking more than 50ms to respond to ping requests and we started getting lots of alerts from *all* our nodes in multiple clusters with > 50 nodes. This was a surprise since it should *NOT* take 50 milliseconds for goldpinger to send a very simple HTTP request and get a response. 

Digging deeper by clicking on a heatmap, things look really bad:

<img width="712" alt="Screen Shot 2020-03-30 at 7 51 29 PM" src="https://user-images.githubusercontent.com/297368/78734147-786e7380-7915-11ea-8af1-fb0d51508c01.png">

Most nodes seem to be taking over `100ms` to respond. After ruling out some form of connection pooling/network throttling, we came to the conclusion that goldpinger was being CPU starved since we had set the CPU requests to 0.05 CPU cores and the limit to 0.1 CPU cores. To check if that was an issue, I manually created a cgroup for goldpinger and ran it locally:

```sh
sudo yum install libcgroup-tools
sudo cgcreate -g cpu:/goldpinger
sudo cgset -r cpu.shares=64  -r cpu.cfs_quota_us=50000 -r cpu.cfs_period_us=1000000 goldpinger
sudo cgexec -g cpu:goldpinger `pwd`/bin/goldpinger --kubeconfig=/kubernetes/conf/1.71.55.136-client-kube-config.yml --client-port-override=80  --host=0.0.0.0 --port=8080
```

and I was able to recreate slow response times. To verify that this is the case, I ran the query in Prometheus:

```
sum(rate(container_cpu_usage_seconds_total{container_name="goldpinger"}[15m])) by (pod_name, container_name) /
sum(container_spec_cpu_shares{container_name="goldpinger"}/container_spec_cpu_period{container_name="goldpinger"}) by (pod_name, container_name)
```

and it appeared that goldpinger was using anywhere between 3-6 times its allocated share. So I updated the CPU requests to `250m` and the limits to `1` and the results are shown on the graph below:

<img width="1647" alt="Screen Shot 2020-03-30 at 9 19 23 PM" src="https://user-images.githubusercontent.com/297368/78736611-8fb05f80-791b-11ea-8536-e5b530af5940.png">

(Ignore the other goldpinger restarts)

## The cause

The reason for this CPU starvation is the current goldpinger design has a thundering herd problem in that it sleeps for 30 seconds and then sends a burst of n requests to n pods all at once, which then in turn send n requests to all their neighbors causing a n^2 runtime. 

## The fix

This fix in this PR is to have each goldpinger pod create a separate goroutine responsible for pinging a single peer. Each goroutine runs continuously at staggered intervals with added jitter to do continuous work and prevent the thundering herd issue. The results are sent over a channel and aggregated in another goroutine.

As a result of this PR, the new heatmap looks like the following, with the same CPU/memory limits:

<img width="723" alt="Screen Shot 2020-04-07 at 9 06 39 PM" src="https://user-images.githubusercontent.com/297368/78736670-bb334a00-791b-11ea-8f16-d451af591bfa.png">

And looking at the CPU/memory usage with `psrecord $(pidof goldpinger)  --interval 0.25 --plot graph.png` there appear to be very few spikes in CPU usage:

![dob1-new](https://user-images.githubusercontent.com/297368/78736696-cbe3c000-791b-11ea-8e26-711d67133e26.png)

# Testing performed

This PR is currently running on a >50 node cluster and has been tested on smaller clusters as well. I did try to delete multiple pods, introduce multiple failures to make sure the code is robust to those changes.

# Additional context

Two issues that might be of concern:
- The [`updateCounters`](https://github.com/skamboj/goldpinger/blob/d68d35bbabbefc2746a2c3bc34542f0343eb945e/pkg/goldpinger/updater.go#L147-L180) is possibly more complicated than I would have liked. I can simplify it if you like by having `collectResults` do an iteration over the map and counting the number of healthy/unhealthy nodes at regular intervals without complicating things.
- In https://github.com/bloomberg/goldpinger/commit/2a78a9cec599a5d12aeabf6d20532317f0824172 I removed the code that pings all the other pods on demand in the `check` call, choosing to return somewhat stale data. I went back and forth on this decision multiple times but then decided it would be better to get a view in the UI of what was reported as being broken rather than to test again. I can revert this commit if you feel otherwise.