### PR TITLE
feat: configurable namespace for pod discovery

### DIFF
--- a/cmd/goldpinger/main.go
+++ b/cmd/goldpinger/main.go
@@ -96,6 +96,12 @@ func main() {
 		os.Exit(code)
 	}
 
+	if goldpinger.GoldpingerConfig.Namespace == nil {
+		goldpinger.GoldpingerConfig.Namespace = &goldpinger.PodNamespace
+	} else {
+		logger.Info("Using configured namespace", zap.String("namespace", *goldpinger.GoldpingerConfig.Namespace))
+	}
+
 	// make a kubernetes client
 	var config *rest.Config
 	if goldpinger.GoldpingerConfig.KubeConfigPath == "" {

--- a/pkg/goldpinger/config.go
+++ b/pkg/goldpinger/config.go
@@ -20,17 +20,18 @@ import (
 
 // GoldpingerConfig represents the configuration for goldpinger
 var GoldpingerConfig = struct {
-	StaticFilePath   string `long:"static-file-path" description:"Folder for serving static files" env:"STATIC_FILE_PATH"`
-	KubeConfigPath   string `long:"kubeconfig" description:"Path to kubeconfig file" env:"KUBECONFIG"`
-	RefreshInterval  int    `long:"refresh-interval" description:"If > 0, will create a thread and collect stats every n seconds" env:"REFRESH_INTERVAL" default:"30"`
+	StaticFilePath   string  `long:"static-file-path" description:"Folder for serving static files" env:"STATIC_FILE_PATH"`
+	KubeConfigPath   string  `long:"kubeconfig" description:"Path to kubeconfig file" env:"KUBECONFIG"`
+	RefreshInterval  int     `long:"refresh-interval" description:"If > 0, will create a thread and collect stats every n seconds" env:"REFRESH_INTERVAL" default:"30"`
 	JitterFactor     float64 `long:"jitter-factor" description:"The amount of jitter to add while pinging clients" env:"JITTER_FACTOR" default:"0.05"`
-	Hostname         string `long:"hostname" description:"Hostname to use" env:"HOSTNAME"`
-	PodIP            string `long:"pod-ip" description:"Pod IP to use" env:"POD_IP"`
-	PodName          string `long:"pod-name" description:"The name of this pod - used to select --ping-number of pods using rendezvous hashing" env:"POD_NAME"`
-	PingNumber       uint   `long:"ping-number" description:"Number of peers to ping. A value of 0 indicates all peers should be pinged." default:"0" env:"PING_NUMBER"`
-	Port             int    `long:"client-port-override" description:"(for testing) use this port when calling other instances" env:"CLIENT_PORT_OVERRIDE"`
-	UseHostIP        bool   `long:"use-host-ip" description:"When making the calls, use host ip (defaults to pod ip)" env:"USE_HOST_IP"`
-	LabelSelector    string `long:"label-selector" description:"label selector to use to discover goldpinger pods in the cluster" env:"LABEL_SELECTOR" default:"app=goldpinger"`
+	Hostname         string  `long:"hostname" description:"Hostname to use" env:"HOSTNAME"`
+	PodIP            string  `long:"pod-ip" description:"Pod IP to use" env:"POD_IP"`
+	PodName          string  `long:"pod-name" description:"The name of this pod - used to select --ping-number of pods using rendezvous hashing" env:"POD_NAME"`
+	PingNumber       uint    `long:"ping-number" description:"Number of peers to ping. A value of 0 indicates all peers should be pinged." default:"0" env:"PING_NUMBER"`
+	Port             int     `long:"client-port-override" description:"(for testing) use this port when calling other instances" env:"CLIENT_PORT_OVERRIDE"`
+	UseHostIP        bool    `long:"use-host-ip" description:"When making the calls, use host ip (defaults to pod ip)" env:"USE_HOST_IP"`
+	LabelSelector    string  `long:"label-selector" description:"label selector to use to discover goldpinger pods in the cluster" env:"LABEL_SELECTOR" default:"app=goldpinger"`
+	Namespace        *string `long:"namespace" description:"namespace to use to discover goldpinger pods in the cluster (empty for all). Defaults to discovering the namespace for the current pod" env:"NAMESPACE"`
 	KubernetesClient *kubernetes.Clientset
 
 	DnsHosts []string `long:"host-to-resolve" description:"A host to attempt dns resolve on (space delimited)" env:"HOSTS_TO_RESOLVE" env-delim:" "`

--- a/pkg/goldpinger/k8s.go
+++ b/pkg/goldpinger/k8s.go
@@ -21,8 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// namespace is the namespace for the goldpinger pod
-var namespace = getNamespace()
+// PodNamespace is the auto-detected namespace for this goldpinger pod
+var PodNamespace = getPodNamespace()
 
 // GoldpingerPod contains just the basic info needed to ping and keep track of a given goldpinger pod
 type GoldpingerPod struct {
@@ -31,7 +31,7 @@ type GoldpingerPod struct {
 	HostIP string // HostIP is the IP address of the host where the pod lives
 }
 
-func getNamespace() string {
+func getPodNamespace() string {
 	b, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		zap.L().Warn("Unable to determine namespace", zap.Error(err))
@@ -44,7 +44,7 @@ func getNamespace() string {
 // GetAllPods returns a mapping from a pod name to a pointer to a GoldpingerPod(s)
 func GetAllPods() map[string]*GoldpingerPod {
 	timer := GetLabeledKubernetesCallsTimer()
-	pods, err := GoldpingerConfig.KubernetesClient.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: GoldpingerConfig.LabelSelector})
+	pods, err := GoldpingerConfig.KubernetesClient.CoreV1().Pods(*GoldpingerConfig.Namespace).List(metav1.ListOptions{LabelSelector: GoldpingerConfig.LabelSelector})
 	if err != nil {
 		zap.L().Error("Error getting pods for selector", zap.String("selector", GoldpingerConfig.LabelSelector), zap.Error(err))
 		CountError("kubernetes_api")


### PR DESCRIPTION
**Describe your changes**
Adds a configuration option to allow for cross-namespace pings.

Our intention is to mainly use `''` ("all namespaces") to handle connectivity probing between namespace-scoped things (network policies, policy-driven webhooks, etc.). I also expect that setting the value to a namespace other than the one containing the pod ran in something of an "query only" mode, in that it aggregates results without showing up in the others' ping targets.

**Testing performed**
I ran Goldpinger pods both with and without the new configuration: without, the pod successfully discovered itself in its own namespace (nothing else was running there), and with the value set to `''` they successfully discovered each other across a namespace boundary.

**Additional context**
The "all-namespaces" behavior is really what I'm after; if y'all would prefer an `--all-namespaces` flag to an explicit namespace, I'm happy to make that change.