### PR TITLE
[WORK IN PROGRESS] Multi-architecture builds for goldpinger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish
+
+on:
+  push:
+    # Publish `v*` tags as releases.
+    tags:
+    - v*
+  pull_request:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.DOCKER_HUB_USERNAME }}/goldpinger
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: GO_MOD_ACTION=download
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: simple
+      -
+        name: Build and push vendor
+        id: docker_build_vendor
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          flavor: |
+            suffix: -vendor,onlatest=false
+          file: ./Dockerfile
+          build-args: GO_MOD_ACTION=vendor
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          target: vendor

--- a/README.md
+++ b/README.md
@@ -68,21 +68,20 @@ The repo comes with two ways of building a `docker` image: compiling locally, an
 You will need `docker` version 17.05+ installed to support multi-stage builds.
 
 ```sh
-# step 1: launch the build
-make build-multistage
+# Build a local container without publishing
+make build
 
-# step 2: push the image somewhere
-namespace="docker.io/myhandle/" make tag
-namespace="docker.io/myhandle/" make push
+# Build & push the image somewhere
+namespace="docker.io/myhandle/" make build-release
 ```
 
 This was contributed via [@michiel](https://github.com/michiel) - kudos !
 
 ### Compiling locally
 
-In order to build `Goldpinger`, you are going to need `go` version 1.13+ and `docker`.
+In order to build `Goldpinger`, you are going to need `go` version 1.15+ and `docker`.
 
-Building from source code consists of compiling the binary and building a [Docker image](./build/Dockerfile-simple):
+Building from source code consists of compiling the binary and building a [Docker image](./Dockerfile):
 
 ```sh
 # step 0: check out the code
@@ -95,11 +94,10 @@ make bin/goldpinger
 ./bin/goldpinger --help
 
 # step 2: build the docker image containing the binary
-make build
+namespace="docker.io/myhandle/" make build
 
 # step 3: push the image somewhere
-namespace="docker.io/myhandle/" make tag
-namespace="docker.io/myhandle/" make push
+docker push $(namespace="docker.io/myhandle/" make version)
 ```
 
 ## Installation

--- a/build/build.sh
+++ b/build/build.sh
@@ -24,18 +24,14 @@ if [ -z "${PKG}" ]; then
     echo "PKG must be set"
     exit 1
 fi
-if [ -z "${ARCH}" ]; then
-    echo "ARCH must be set"
-    exit 1
-fi
 if [ -z "${VERSION}" ]; then
     echo "VERSION must be set"
     exit 1
 fi
 
 export CGO_ENABLED=0
-export GOARCH="${ARCH}"
-export GOOS=${GOOS:-}
+export GOARCH="${ARCH:-amd64}"
+export GOOS=${GOOS:-linux}
 
 go build \
     -ldflags "-X 'main.Version=${VERSION}' -X 'main.Build=`date`'" \

--- a/docker_deploy.sh
+++ b/docker_deploy.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
 
 docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD" \
-    && make tag \
-    && make push \
-    && make vendor-tag \
-    && make vendor-push
-
+    && make build-release

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bloomberg/goldpinger/v3
 
-go 1.14
+go 1.15
 
 require (
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #94*

**Describe your changes**
This does a multi-stage, multi-architecture build for goldpinger.

**Testing performed**
Docker build, pushed to internal repository, ran in kubernetes, verified metrics available.

**Additional context**
@seeker89 mentioned that they'll be moving to GH actions so I included an example setup of the action to build & publish on new tags. GH action hasn't been fully tested for the `-vendor` builds.
