### PR TITLE
Display hostName other than podName

### DIFF
--- a/pkg/goldpinger/config.go
+++ b/pkg/goldpinger/config.go
@@ -32,6 +32,7 @@ var GoldpingerConfig = struct {
 	UseHostIP        bool    `long:"use-host-ip" description:"When making the calls, use host ip (defaults to pod ip)" env:"USE_HOST_IP"`
 	LabelSelector    string  `long:"label-selector" description:"label selector to use to discover goldpinger pods in the cluster" env:"LABEL_SELECTOR" default:"app=goldpinger"`
 	Namespace        *string `long:"namespace" description:"namespace to use to discover goldpinger pods in the cluster (empty for all). Defaults to discovering the namespace for the current pod" env:"NAMESPACE"`
+	DisplayNodeName  bool    `long:"display-nodename" description:"Display nodename other than podname in UI (defaults is podname)." env:"DISPLAY_NODENAME"`
 	KubernetesClient *kubernetes.Clientset
 
 	DnsHosts []string `long:"host-to-resolve" description:"A host to attempt dns resolve on (space delimited)" env:"HOSTS_TO_RESOLVE" env-delim:" "`

--- a/pkg/goldpinger/k8s.go
+++ b/pkg/goldpinger/k8s.go
@@ -95,7 +95,7 @@ func getPodIP(p v1.Pod) string {
 }
 
 func getPodNodeName(p v1.Pod) string {
-	if p.Spec.NodeName != "" {
+	if GoldpingerConfig.DisplayNodeName {
 		return p.Spec.NodeName
 	}
 

--- a/pkg/goldpinger/k8s.go
+++ b/pkg/goldpinger/k8s.go
@@ -16,8 +16,9 @@ package goldpinger
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"io/ioutil"
+
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8snet "k8s.io/utils/net"
@@ -93,6 +94,14 @@ func getPodIP(p v1.Pod) string {
 	return podIP
 }
 
+func getPodNodeName(p v1.Pod) string {
+	if p.Spec.NodeName != "" {
+		return p.Spec.NodeName
+	}
+
+	return p.Name
+}
+
 // GetAllPods returns a mapping from a pod name to a pointer to a GoldpingerPod(s)
 func GetAllPods() map[string]*GoldpingerPod {
 	timer := GetLabeledKubernetesCallsTimer()
@@ -111,7 +120,7 @@ func GetAllPods() map[string]*GoldpingerPod {
 	podMap := make(map[string]*GoldpingerPod)
 	for _, pod := range pods.Items {
 		podMap[pod.Name] = &GoldpingerPod{
-			Name:   pod.Name,
+			Name:   getPodNodeName(pod),
 			PodIP:  getPodIP(pod),
 			HostIP: getHostIP(pod),
 		}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
I changed `pod.Name` to `p.Spec.NodeName`, so we can see the nodename other than podname in the UI.
![image](https://user-images.githubusercontent.com/18480426/162653875-61e0a51e-c2ef-4f0b-b9b3-30d513da5d1f.png)

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
goldpinger is deployed by daemonset, so nodename is better than podname.