### PR TITLE
Fix pinger be removed by not found.

### DIFF
--- a/pkg/goldpinger/updater.go
+++ b/pkg/goldpinger/updater.go
@@ -34,8 +34,8 @@ var checkResultsMux = sync.Mutex{}
 // - there is already a pinger with the same name
 // - the pinger has the same podIP
 // - the pinger has the same hostIP
-func exists(existingPods map[string]*GoldpingerPod, new *GoldpingerPod) bool {
-	old, exists := existingPods[new.Name]
+func exists(existingPods map[string]*GoldpingerPod, podName string, new *GoldpingerPod) bool {
+	old, exists := existingPods[podName]
 	return exists && (old.PodIP == new.PodIP) && (old.HostIP == new.HostIP)
 }
 
@@ -61,7 +61,7 @@ func updatePingers(resultsChan chan<- PingAllPodsResult) {
 
 		latest := SelectPods()
 		for podName, pod := range latest {
-			if exists(existingPods, pod) {
+			if exists(existingPods, podName, pod) {
 				// This pod continues to exist in the latest iteration of the update
 				// without any changes
 				// Delete it from the set of pods that we wish to delete


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

heatmap will be broken in every refeshPeriod,
I found pinger is be deleted because of exists check faild.

updatePingers will check if a pod still exist or a new one,
and update pingers in every refreshPeriod.

the function exists failed to check pod exist, so fix it.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
