### PR TITLE
[Bug Fix] add missing dependency

### DIFF
--- a/cmd/goldpinger/main.go
+++ b/cmd/goldpinger/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/go-openapi/loads"
 	"go.uber.org/zap"


### PR DESCRIPTION
CI for https://github.com/bloomberg/goldpinger/pull/115 failed of a missing an import in main.go: 

https://github.com/bloomberg/goldpinger/runs/8043769389?check_suite_focus=true

Apologies I must have made a mistake when rebasing.


Signed-off-by: kitfoman <thaddeusgetachew@gmail.com>
