### PR TITLE
Remove deprecated rbac.authorization.k8s.io/v1beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Note, that you will also need to add an RBAC rule to allow `Goldpinger` to list 
 
 ```yaml
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: default

--- a/extras/example-serviceaccounts.yml
+++ b/extras/example-serviceaccounts.yml
@@ -102,7 +102,7 @@ rules:
   - list
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: goldpinger-clusterrolebinding


### PR DESCRIPTION
**Describe your changes**
This commit updates the README and examples to use rbac.authorization.k8s.io/v1, which has been available since K8s 1.8
rbac.authorization.k8s.io/v1beta1 was deprecated in K8s 1.17 and removed in K8s 1.22.

**Testing performed**
Used `kubectl apply` with the updated manifests from the README in a K8s cluster running 1.23.

**Additional context**
Deprecation notice: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122

