### PR TITLE
use protobuf and add resourceVersion in listOption

### DIFF
--- a/cmd/goldpinger/main.go
+++ b/cmd/goldpinger/main.go
@@ -20,10 +20,12 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-openapi/loads"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -131,6 +133,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Error getting config ", zap.Error(err))
 	}
+	// communicate to kube-apiserver with protobuf
+	config.AcceptContentTypes = strings.Join([]string{runtime.ContentTypeProtobuf, runtime.ContentTypeJSON}, ",")
+	config.ContentType = runtime.ContentTypeProtobuf
+
 	// create the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/pkg/goldpinger/k8s.go
+++ b/pkg/goldpinger/k8s.go
@@ -107,6 +107,8 @@ func getPodNodeName(p v1.Pod) string {
 func GetAllPods() map[string]*GoldpingerPod {
 	timer := GetLabeledKubernetesCallsTimer()
 	listOpts := metav1.ListOptions{
+		ResourceVersion: "0",
+
 		LabelSelector: GoldpingerConfig.LabelSelector,
 		FieldSelector: "status.phase=Running", // only select Running pods, otherwise we will get them before they have IPs
 	}


### PR DESCRIPTION
1. communicate to kube-apiserver with protobuf
2. listOption add resourceVersion=0. without resourceversion, list will force kube-apiserver retrieve data from etcd.

In a 100+ nodes, 7500+ pods kubernetes cluster, this patch make kube-apiserver cpu utils reduce 5-10%.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
