### PR TITLE
Add default namespace `default` to ServiceAccount definition in example yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: goldpinger-serviceaccount
+  namespace: default
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
This is to catch the case where users find-replace the `default` namespace with another namespace (say, `goldpinger` but don't change it for the ServiceAccount definition.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
Added a `namespace` key under `metadata` with corresponding namespace (`default`) used elsewhere in the sample yaml.

**Testing performed**
Tested on prem, k8s 1.27 with `kubectl apply -f file.yaml`.

**Additional context**
N/A.
