### PR TITLE
Active / passive node sharding to reduce API server load

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Oh, and it gives you the graph below for your cluster. Check out the [video expl
     - [Example YAML](#example-yaml)
     - [Note on DNS](#note-on-dns)
     - [UDP probe for packet loss, hop count, and RTT](#udp-probe-for-packet-loss-hop-count-and-rtt)
+    - [Active/passive node sharding](#activepassive-node-sharding)
   - [Usage](#usage)
     - [UI](#ui)
     - [API](#api)
@@ -340,6 +341,74 @@ Links with partial loss are shown as yellow edges in the graph UI, and edge labe
 
 No new dependencies are required (`golang.org/x/net` is already in go.mod), and no additional container capabilities are needed.
 
+### Active/passive node sharding
+
+At scale, every goldpinger pod list-watches all pods via the Kubernetes API server. With hundreds or thousands of nodes, this creates N concurrent list-watches that can overwhelm the API server and trigger cascading failures.
+
+Active/passive sharding lets you configure a percentage of nodes as **active** (list-watch + ping peers) while the rest are **passive** (only respond to `/ping`). Active nodes still ping passive nodes, so connectivity is validated across the entire cluster with a fraction of the API server load.
+
+#### Configuration
+
+| Method | Example |
+|--------|---------|
+| Env var | `ACTIVE_NODE_PERCENTAGE=10` |
+| CLI flag | `--active-node-percentage=10` |
+| Helm | `goldpinger.activeNodePercentage: 10` |
+
+The default is `100` (all nodes active) — fully backwards compatible.
+
+#### Forcing specific nodes active
+
+For small clusters or when you need a guarantee that specific nodes are always active:
+
+| Method | Example |
+|--------|---------|
+| Env var | `ACTIVE_NODES=node-1,node-2` |
+| CLI flag | `--active-nodes=node-1,node-2` |
+| Helm | `goldpinger.activeNodes: [node-1, node-2]` |
+
+Nodes in this list are always active, regardless of the percentage hash.
+
+> **Note for small clusters:** The hash-based percentage is probabilistic. With fewer than ~20 nodes and a low percentage, it's possible all nodes hash into the passive range. Use `ACTIVE_NODES` to guarantee at least one active node.
+
+#### How it works
+
+Each pod hashes its own node name (from `spec.nodeName`) using FNV-1a and checks if `hash % 100 < percentage`. This is deterministic — the same node always gets the same role across restarts, with no inter-pod coordination.
+
+> **Mode is evaluated once at startup and never changes while the pod is running.** To change a node from passive to active (or vice versa), update the configuration and perform a **DaemonSet rolling restart** (`kubectl rollout restart daemonset/goldpinger`). This design is intentional: it means passive nodes make zero API server calls for their entire lifetime, which is ideal for large clusters.
+
+
+#### Behavior by mode
+
+| Endpoint | Active | Passive |
+|----------|--------|---------|
+| `GET /ping` | 200 | 200 |
+| `GET /healthz` | 200 | 200 |
+| `GET /metrics` | Full metrics | Mode metric only |
+| `GET /check` | 200 | 503 |
+| `GET /check_all` | 200 | 503 |
+| `GET /cluster_health` | 200 | 503 |
+
+Passive nodes skip Kubernetes client creation entirely — no list-watch, no API server load.
+
+#### Monitoring
+
+The `goldpinger_node_mode` Prometheus metric indicates the node's mode: `1` for active, `0` for passive. You can use this to verify your sharding configuration:
+
+```promql
+# Count active vs passive nodes
+count(goldpinger_node_mode == 1)  # active nodes
+count(goldpinger_node_mode == 0)  # passive nodes
+```
+
+#### Example: 1000-node cluster
+
+| Config | API server list-watches | Nodes pinged |
+|--------|------------------------|--------------|
+| Default (100%) | 1000 | 1000 |
+| 10% | ~100 | 1000 |
+| 1% | ~10 | 1000 |
+
 ## Usage
 
 ### UI
@@ -374,6 +443,7 @@ goldpinger_peers_hop_count          # (UDP probe, when enabled)
 goldpinger_peers_udp_rtt_s_*        # (UDP probe, when enabled)
 goldpinger_udp_duplicates_total     # (UDP probe, when enabled)
 goldpinger_udp_out_of_order_total   # (UDP probe, when enabled)
+goldpinger_node_mode                # 1 = active, 0 = passive (active/passive sharding)
 ```
 
 ### Grafana

--- a/charts/goldpinger/templates/daemonset.yaml
+++ b/charts/goldpinger/templates/daemonset.yaml
@@ -50,6 +50,14 @@ spec:
               value: "{{ .Values.goldpinger.port }}"
             - name: LABEL_SELECTOR
               value: "app.kubernetes.io/name={{ include "goldpinger.name" . }}"
+            {{- if ne (int .Values.goldpinger.activeNodePercentage) 100 }}
+            - name: ACTIVE_NODE_PERCENTAGE
+              value: "{{ .Values.goldpinger.activeNodePercentage }}"
+            {{- end }}
+            {{- if .Values.goldpinger.activeNodes }}
+            - name: ACTIVE_NODES
+              value: "{{ join "," .Values.goldpinger.activeNodes }}"
+            {{- end }}
             {{- if .Values.goldpinger.udp.enabled }}
             - name: UDP_ENABLED
               value: "true"

--- a/charts/goldpinger/values.yaml
+++ b/charts/goldpinger/values.yaml
@@ -23,6 +23,13 @@ serviceAccount:
 
 goldpinger:
   port: 8080
+  # Percentage of nodes (1-100) that are "active" (list-watch + ping).
+  # Remaining nodes are "passive" (respond to /ping only, no API server load).
+  # For small clusters, also set activeNodes to guarantee at least one active node.
+  activeNodePercentage: 100
+  # List of node names that should always be active, regardless of percentage hash.
+  # Recommended for small clusters to guarantee at least one active node.
+  activeNodes: []
   udp:
     enabled: false
     port: 6969

--- a/cmd/goldpinger/main.go
+++ b/cmd/goldpinger/main.go
@@ -98,6 +98,15 @@ func main() {
 		os.Exit(code)
 	}
 
+	// Handle --check-node-hash: print bucket info and exit
+	if len(goldpinger.GoldpingerConfig.CheckNodeHash) > 0 {
+		for _, name := range goldpinger.GoldpingerConfig.CheckNodeHash {
+			bucket := goldpinger.NodeHashBucket(name)
+			fmt.Printf("%s: bucket %d (active when ACTIVE_NODE_PERCENTAGE >= %d)\n", name, bucket, bucket+1)
+		}
+		os.Exit(0)
+	}
+
 	// Configure logger
 	logger, err := getLogger(goldpinger.GoldpingerConfig.ZapConfigPath)
 	if err != nil {
@@ -115,77 +124,116 @@ func main() {
 
 	logger.Info("Goldpinger", zap.String("version", Version), zap.String("build", Build))
 
-	if goldpinger.GoldpingerConfig.Namespace == nil {
-		goldpinger.GoldpingerConfig.Namespace = &goldpinger.PodNamespace
+	// Determine node mode (active/passive sharding)
+	goldpinger.NodeMode = goldpinger.DetermineNodeMode(
+		goldpinger.GoldpingerConfig.Hostname,
+		goldpinger.GoldpingerConfig.ActiveNodePercentage,
+		goldpinger.GoldpingerConfig.ActiveNodes,
+	)
+	logger.Info("Node mode determined",
+		zap.String("hostname", goldpinger.GoldpingerConfig.Hostname),
+		zap.String("mode", goldpinger.NodeMode),
+		zap.Int("activeNodePercentage", goldpinger.GoldpingerConfig.ActiveNodePercentage),
+		zap.Strings("activeNodes", goldpinger.GoldpingerConfig.ActiveNodes),
+	)
+	if goldpinger.GoldpingerConfig.Hostname == "" {
+		logger.Warn("Empty hostname, defaulting to active mode")
+	}
+	if goldpinger.GoldpingerConfig.ActiveNodePercentage < 1 {
+		logger.Warn("ACTIVE_NODE_PERCENTAGE below minimum, clamping to 1",
+			zap.Int("configured", goldpinger.GoldpingerConfig.ActiveNodePercentage))
+	}
+	if goldpinger.GoldpingerConfig.ActiveNodePercentage > 100 {
+		logger.Warn("ACTIVE_NODE_PERCENTAGE above maximum, clamping to 100",
+			zap.Int("configured", goldpinger.GoldpingerConfig.ActiveNodePercentage))
+	}
+	if goldpinger.NodeMode == goldpinger.NodeModePassive && len(goldpinger.GoldpingerConfig.ActiveNodes) == 0 {
+		logger.Warn("Passive node with no ACTIVE_NODES set. In small clusters, all nodes may be passive. Set ACTIVE_NODES to guarantee at least one active node.",
+			zap.Int("activeNodePercentage", goldpinger.GoldpingerConfig.ActiveNodePercentage),
+			zap.String("hostname", goldpinger.GoldpingerConfig.Hostname),
+		)
+	}
+	goldpinger.SetNodeMode(goldpinger.NodeMode)
+
+	if goldpinger.IsActiveNode() {
+		if goldpinger.GoldpingerConfig.Namespace == nil {
+			goldpinger.GoldpingerConfig.Namespace = &goldpinger.PodNamespace
+		} else {
+			logger.Info("Using configured namespace", zap.String("namespace", *goldpinger.GoldpingerConfig.Namespace))
+		}
+
+		// make a kubernetes client
+		var config *rest.Config
+		if goldpinger.GoldpingerConfig.KubeConfigPath == "" {
+			logger.Info("Kubeconfig not specified, trying to use in cluster config")
+			config, err = rest.InClusterConfig()
+		} else {
+			logger.Info("Kubeconfig specified", zap.String("path", goldpinger.GoldpingerConfig.KubeConfigPath))
+			config, err = clientcmd.BuildConfigFromFlags("", goldpinger.GoldpingerConfig.KubeConfigPath)
+		}
+		if err != nil {
+			logger.Fatal("Error getting config ", zap.Error(err))
+		}
+		// communicate to kube-apiserver with protobuf
+		config.AcceptContentTypes = strings.Join([]string{runtime.ContentTypeProtobuf, runtime.ContentTypeJSON}, ",")
+		config.ContentType = runtime.ContentTypeProtobuf
+
+		// create the clientset
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			logger.Fatal("kubernetes.NewForConfig error ", zap.Error(err))
+		}
+		goldpinger.GoldpingerConfig.KubernetesClient = clientset
+
+		// Check if we have an override for the client, default to own port
+		if goldpinger.GoldpingerConfig.Port == 0 {
+			goldpinger.GoldpingerConfig.Port = server.Port
+		}
+
+		if goldpinger.GoldpingerConfig.PodIP == "" {
+			logger.Info("PodIP not set: pinging all pods")
+		}
+		if goldpinger.GoldpingerConfig.PingNumber == 0 {
+			logger.Info("--ping-number set to 0: pinging all pods")
+		}
+		if goldpinger.GoldpingerConfig.IPVersions == nil || len(goldpinger.GoldpingerConfig.IPVersions) == 0 {
+			logger.Info("IPVersions not set: settings to 4 (IPv4)")
+			goldpinger.GoldpingerConfig.IPVersions = []string{"4"}
+		}
+		if len(goldpinger.GoldpingerConfig.IPVersions) > 1 {
+			logger.Warn("Multiple IP versions not supported. Will use first version specified as default", zap.Strings("IPVersions", goldpinger.GoldpingerConfig.IPVersions))
+		}
+		if goldpinger.GoldpingerConfig.IPVersions[0] != string(net.IPv4) && goldpinger.GoldpingerConfig.IPVersions[0] != string(net.IPv6) {
+			logger.Error("Unknown IP version specified: expected values are 4 or 6", zap.Strings("IPVersions", goldpinger.GoldpingerConfig.IPVersions))
+		}
+
+		// Handle deprecated flags
+		if int(goldpinger.GoldpingerConfig.PingTimeout) == 0 {
+			logger.Warn("ping-timeout-ms is deprecated in favor of ping-timeout and will be removed in the future",
+				zap.Int64("ping-timeout-ms", goldpinger.GoldpingerConfig.PingTimeoutMs))
+			goldpinger.GoldpingerConfig.PingTimeout = time.Duration(goldpinger.GoldpingerConfig.PingTimeoutMs) * time.Millisecond
+		}
+		if int(goldpinger.GoldpingerConfig.CheckTimeout) == 0 {
+			logger.Warn("check-timeout-ms is deprecated in favor of check-timeout and will be removed in the future",
+				zap.Int64("check-timeout-ms", goldpinger.GoldpingerConfig.CheckTimeoutMs))
+			goldpinger.GoldpingerConfig.CheckTimeout = time.Duration(goldpinger.GoldpingerConfig.CheckTimeoutMs) * time.Millisecond
+		}
+		if int(goldpinger.GoldpingerConfig.CheckAllTimeout) == 0 {
+			logger.Warn("check-all-timeout-ms is deprecated in favor of check-all-timeout will be removed in the future",
+				zap.Int64("check-all-timeout-ms", goldpinger.GoldpingerConfig.CheckAllTimeoutMs))
+			goldpinger.GoldpingerConfig.CheckAllTimeout = time.Duration(goldpinger.GoldpingerConfig.CheckAllTimeoutMs) * time.Millisecond
+		}
+
+		server.ConfigureAPI()
+		goldpinger.StartUpdater()
 	} else {
-		logger.Info("Using configured namespace", zap.String("namespace", *goldpinger.GoldpingerConfig.Namespace))
+		logger.Info("Running in passive mode - serving /ping, /healthz, /metrics (+ UDP listener if enabled) only. No k8s API calls will be made. Restart the DaemonSet to re-evaluate mode.")
+		server.ConfigureAPI()
 	}
 
-	// make a kubernetes client
-	var config *rest.Config
-	if goldpinger.GoldpingerConfig.KubeConfigPath == "" {
-		logger.Info("Kubeconfig not specified, trying to use in cluster config")
-		config, err = rest.InClusterConfig()
-	} else {
-		logger.Info("Kubeconfig specified", zap.String("path", goldpinger.GoldpingerConfig.KubeConfigPath))
-		config, err = clientcmd.BuildConfigFromFlags("", goldpinger.GoldpingerConfig.KubeConfigPath)
-	}
-	if err != nil {
-		logger.Fatal("Error getting config ", zap.Error(err))
-	}
-	// communicate to kube-apiserver with protobuf
-	config.AcceptContentTypes = strings.Join([]string{runtime.ContentTypeProtobuf, runtime.ContentTypeJSON}, ",")
-	config.ContentType = runtime.ContentTypeProtobuf
-
-	// create the clientset
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		logger.Fatal("kubernetes.NewForConfig error ", zap.Error(err))
-	}
-	goldpinger.GoldpingerConfig.KubernetesClient = clientset
-
-	// Check if we have an override for the client, default to own port
-	if goldpinger.GoldpingerConfig.Port == 0 {
-		goldpinger.GoldpingerConfig.Port = server.Port
-	}
-
-	if goldpinger.GoldpingerConfig.PodIP == "" {
-		logger.Info("PodIP not set: pinging all pods")
-	}
-	if goldpinger.GoldpingerConfig.PingNumber == 0 {
-		logger.Info("--ping-number set to 0: pinging all pods")
-	}
-	if goldpinger.GoldpingerConfig.IPVersions == nil || len(goldpinger.GoldpingerConfig.IPVersions) == 0 {
-		logger.Info("IPVersions not set: settings to 4 (IPv4)")
-		goldpinger.GoldpingerConfig.IPVersions = []string{"4"}
-	}
-	if len(goldpinger.GoldpingerConfig.IPVersions) > 1 {
-		logger.Warn("Multiple IP versions not supported. Will use first version specified as default", zap.Strings("IPVersions", goldpinger.GoldpingerConfig.IPVersions))
-	}
-	if goldpinger.GoldpingerConfig.IPVersions[0] != string(net.IPv4) && goldpinger.GoldpingerConfig.IPVersions[0] != string(net.IPv6) {
-		logger.Error("Unknown IP version specified: expected values are 4 or 6", zap.Strings("IPVersions", goldpinger.GoldpingerConfig.IPVersions))
-	}
-
-	// Handle deprecated flags
-	if int(goldpinger.GoldpingerConfig.PingTimeout) == 0 {
-		logger.Warn("ping-timeout-ms is deprecated in favor of ping-timeout and will be removed in the future",
-			zap.Int64("ping-timeout-ms", goldpinger.GoldpingerConfig.PingTimeoutMs))
-		goldpinger.GoldpingerConfig.PingTimeout = time.Duration(goldpinger.GoldpingerConfig.PingTimeoutMs) * time.Millisecond
-	}
-	if int(goldpinger.GoldpingerConfig.CheckTimeout) == 0 {
-		logger.Warn("check-timeout-ms is deprecated in favor of check-timeout and will be removed in the future",
-			zap.Int64("check-timeout-ms", goldpinger.GoldpingerConfig.CheckTimeoutMs))
-		goldpinger.GoldpingerConfig.CheckTimeout = time.Duration(goldpinger.GoldpingerConfig.CheckTimeoutMs) * time.Millisecond
-	}
-	if int(goldpinger.GoldpingerConfig.CheckAllTimeout) == 0 {
-		logger.Warn("check-all-timeout-ms is deprecated in favor of check-all-timeout will be removed in the future",
-			zap.Int64("check-all-timeout-ms", goldpinger.GoldpingerConfig.CheckAllTimeoutMs))
-		goldpinger.GoldpingerConfig.CheckAllTimeout = time.Duration(goldpinger.GoldpingerConfig.CheckAllTimeoutMs) * time.Millisecond
-	}
-
-	server.ConfigureAPI()
-	goldpinger.StartUpdater()
-
+	// UDP listener runs regardless of active/passive mode so active peers can
+	// measure UDP connectivity to passive nodes. Passive only disables outbound
+	// pinging and k8s API calls, not responding to inbound probes.
 	if goldpinger.GoldpingerConfig.UDPEnabled {
 		go goldpinger.StartUDPListener(goldpinger.GoldpingerConfig.UDPPort)
 	}

--- a/pkg/goldpinger/config.go
+++ b/pkg/goldpinger/config.go
@@ -27,7 +27,10 @@ var GoldpingerConfig = struct {
 	KubeConfigPath   string  `long:"kubeconfig" description:"Path to kubeconfig file" env:"KUBECONFIG"`
 	RefreshInterval  int     `long:"refresh-interval" description:"If > 0, will create a thread and collect stats every n seconds" env:"REFRESH_INTERVAL" default:"30"`
 	JitterFactor     float64 `long:"jitter-factor" description:"The amount of jitter to add while pinging clients" env:"JITTER_FACTOR" default:"0.05"`
-	Hostname         string  `long:"hostname" description:"Hostname to use" env:"HOSTNAME"`
+	Hostname             string   `long:"hostname" description:"Hostname to use" env:"HOSTNAME"`
+	ActiveNodePercentage int      `long:"active-node-percentage" description:"Percentage of nodes (1-100) that should be active (list-watch + ping). Remaining nodes are passive (respond only)." env:"ACTIVE_NODE_PERCENTAGE" default:"100"`
+	ActiveNodes          []string `long:"active-nodes" description:"Comma-separated list of node names that should always be active, regardless of percentage hash" env:"ACTIVE_NODES" env-delim:","`
+	CheckNodeHash        []string `long:"check-node-hash" description:"Print hash bucket for given node name(s) and exit. Useful for predicting active/passive assignment."`
 	PodIP            string  `long:"pod-ip" description:"Pod IP to use" env:"POD_IP"`
 	PodName          string  `long:"pod-name" description:"The name of this pod - used to select --ping-number of pods using rendezvous hashing" env:"POD_NAME"`
 	PingNumber       uint    `long:"ping-number" description:"Number of peers to ping. A value of 0 indicates all peers should be pinged." default:"0" env:"PING_NUMBER"`

--- a/pkg/goldpinger/node_mode.go
+++ b/pkg/goldpinger/node_mode.go
@@ -1,0 +1,85 @@
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldpinger
+
+import (
+	"hash/fnv"
+)
+
+// NodeMode holds the determined mode for this node ("active" or "passive").
+// Set once at startup, read thereafter.
+var NodeMode string
+
+const (
+	NodeModeActive  = "active"
+	NodeModePassive = "passive"
+)
+
+// DetermineNodeMode decides whether this node should be active or passive.
+//
+// Priority:
+//  1. If hostname appears in activeNodes list -> active (explicit override)
+//  2. If FNV-1a(hostname) % 100 < percentage -> active (hash-based)
+//  3. Otherwise -> passive
+//
+// percentage is clamped to [1, 100]. An empty hostname is treated as active
+// (fail-open: a misconfigured pod should not silently go passive).
+func DetermineNodeMode(hostname string, percentage int, activeNodes []string) string {
+	// Fail-open: if hostname is empty, be active to avoid silent failures
+	if hostname == "" {
+		return NodeModeActive
+	}
+
+	// Check explicit override list first
+	for _, name := range activeNodes {
+		if name == hostname {
+			return NodeModeActive
+		}
+	}
+
+	// Clamp percentage
+	if percentage < 1 {
+		percentage = 1
+	}
+	if percentage > 100 {
+		percentage = 100
+	}
+
+	// 100% means all active, skip hashing
+	if percentage >= 100 {
+		return NodeModeActive
+	}
+
+	// FNV-1a hash of hostname
+	bucket := NodeHashBucket(hostname)
+
+	if bucket < uint32(percentage) {
+		return NodeModeActive
+	}
+
+	return NodeModePassive
+}
+
+// NodeHashBucket returns the hash bucket (0-99) for a given hostname.
+func NodeHashBucket(hostname string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(hostname))
+	return h.Sum32() % 100
+}
+
+// IsActiveNode returns true if this node is in active mode.
+func IsActiveNode() bool {
+	return NodeMode == NodeModeActive
+}

--- a/pkg/goldpinger/node_mode_test.go
+++ b/pkg/goldpinger/node_mode_test.go
@@ -1,0 +1,107 @@
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldpinger
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDetermineNodeMode_Percentage100AlwaysActive(t *testing.T) {
+	hostnames := []string{"node-1", "node-2", "worker-abc", "ip-10-0-1-5"}
+	for _, h := range hostnames {
+		mode := DetermineNodeMode(h, 100, nil)
+		if mode != NodeModeActive {
+			t.Errorf("Expected active for hostname %q at 100%%, got %s", h, mode)
+		}
+	}
+}
+
+func TestDetermineNodeMode_Percentage0ClampsTo1(t *testing.T) {
+	// At 1%, most hostnames should be passive, but it shouldn't panic or error
+	mode := DetermineNodeMode("test-node", 0, nil)
+	if mode != NodeModeActive && mode != NodeModePassive {
+		t.Errorf("Expected active or passive, got %s", mode)
+	}
+}
+
+func TestDetermineNodeMode_PercentageAbove100ClampsTo100(t *testing.T) {
+	mode := DetermineNodeMode("test-node", 150, nil)
+	if mode != NodeModeActive {
+		t.Errorf("Expected active for percentage > 100, got %s", mode)
+	}
+}
+
+func TestDetermineNodeMode_ActiveNodesOverride(t *testing.T) {
+	// Even at 1% where hash would likely be passive, explicit list wins
+	activeNodes := []string{"forced-node"}
+	mode := DetermineNodeMode("forced-node", 1, activeNodes)
+	if mode != NodeModeActive {
+		t.Errorf("Expected active for node in ACTIVE_NODES list, got %s", mode)
+	}
+}
+
+func TestDetermineNodeMode_ActiveNodesNoMatchFallsToHash(t *testing.T) {
+	activeNodes := []string{"other-node"}
+	// At 100%, hash would make it active anyway
+	mode := DetermineNodeMode("test-node", 100, activeNodes)
+	if mode != NodeModeActive {
+		t.Errorf("Expected active at 100%%, got %s", mode)
+	}
+}
+
+func TestDetermineNodeMode_EmptyHostnameFailsOpen(t *testing.T) {
+	mode := DetermineNodeMode("", 1, nil)
+	if mode != NodeModeActive {
+		t.Errorf("Expected active for empty hostname (fail-open), got %s", mode)
+	}
+}
+
+func TestDetermineNodeMode_Deterministic(t *testing.T) {
+	hostname := "consistent-node-name"
+	first := DetermineNodeMode(hostname, 50, nil)
+	for i := 0; i < 100; i++ {
+		result := DetermineNodeMode(hostname, 50, nil)
+		if result != first {
+			t.Fatalf("Non-deterministic result on iteration %d: got %s, expected %s", i, result, first)
+		}
+	}
+}
+
+func TestDetermineNodeMode_DistributionAt50Percent(t *testing.T) {
+	active := 0
+	total := 10000
+	for i := 0; i < total; i++ {
+		hostname := fmt.Sprintf("node-%d", i)
+		if DetermineNodeMode(hostname, 50, nil) == NodeModeActive {
+			active++
+		}
+	}
+	ratio := float64(active) / float64(total)
+	if ratio < 0.40 || ratio > 0.60 {
+		t.Errorf("Expected ~50%% active at 50%% setting, got %.1f%% (%d/%d)", ratio*100, active, total)
+	}
+}
+
+func TestIsActiveNode(t *testing.T) {
+	NodeMode = NodeModeActive
+	if !IsActiveNode() {
+		t.Error("Expected IsActiveNode() to return true when NodeMode is active")
+	}
+	NodeMode = NodeModePassive
+	if IsActiveNode() {
+		t.Error("Expected IsActiveNode() to return false when NodeMode is passive")
+	}
+}

--- a/pkg/goldpinger/stats.go
+++ b/pkg/goldpinger/stats.go
@@ -189,6 +189,15 @@ var (
 			"pod_ip",
 		},
 	)
+	goldpingerNodeModeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "goldpinger_node_mode",
+			Help: "1 when node is active (list-watch + ping), 0 when passive (respond only)",
+		},
+		[]string{
+			"goldpinger_instance",
+		},
+	)
 	bootTime = time.Now()
 )
 
@@ -208,6 +217,7 @@ func init() {
 	prometheus.MustRegister(goldpingerUDPErrorsCounter)
 	prometheus.MustRegister(goldpingerUDPDuplicatesCounter)
 	prometheus.MustRegister(goldpingerUDPOutOfOrderCounter)
+	prometheus.MustRegister(goldpingerNodeModeGauge)
 	zap.L().Info("Metrics setup - see /metrics")
 }
 
@@ -216,6 +226,17 @@ func GetStats(ctx context.Context) *models.PingResults {
 	return &models.PingResults{
 		BootTime: strfmt.DateTime(bootTime),
 	}
+}
+
+// SetNodeMode sets the node mode gauge metric (1 = active, 0 = passive)
+func SetNodeMode(mode string) {
+	val := 0.0
+	if mode == NodeModeActive {
+		val = 1.0
+	}
+	goldpingerNodeModeGauge.WithLabelValues(
+		GoldpingerConfig.Hostname,
+	).Set(val)
 }
 
 // counts various calls received and made

--- a/pkg/restapi/configure_goldpinger.go
+++ b/pkg/restapi/configure_goldpinger.go
@@ -69,6 +69,9 @@ func configureAPI(api *operations.GoldpingerAPI) http.Handler {
 
 	api.CheckServicePodsHandler = operations.CheckServicePodsHandlerFunc(
 		func(params operations.CheckServicePodsParams) middleware.Responder {
+			if !goldpinger.IsActiveNode() {
+				return middleware.Error(503, "this node is in passive mode and does not perform active checks")
+			}
 			goldpinger.CountCall("received", "check")
 
 			ctx, cancel := context.WithTimeout(
@@ -82,6 +85,9 @@ func configureAPI(api *operations.GoldpingerAPI) http.Handler {
 
 	api.CheckAllPodsHandler = operations.CheckAllPodsHandlerFunc(
 		func(params operations.CheckAllPodsParams) middleware.Responder {
+			if !goldpinger.IsActiveNode() {
+				return middleware.Error(503, "this node is in passive mode and does not perform active checks")
+			}
 			goldpinger.CountCall("received", "check_all")
 
 			ctx, cancel := context.WithTimeout(
@@ -95,6 +101,9 @@ func configureAPI(api *operations.GoldpingerAPI) http.Handler {
 
 	api.ClusterHealthHandler = operations.ClusterHealthHandlerFunc(
 		func(params operations.ClusterHealthParams) middleware.Responder {
+			if !goldpinger.IsActiveNode() {
+				return middleware.Error(503, "this node is in passive mode and does not perform active checks")
+			}
 			goldpinger.CountCall("received", "cluster_health")
 
 			ctx, cancel := context.WithTimeout(


### PR DESCRIPTION
## Summary

- Add `ACTIVE_NODE_PERCENTAGE` (1-100, default 100) and `ACTIVE_NODES` (CSV) config to let only a subset of goldpinger DaemonSet pods actively list-watch the k8s API and ping peers
- Passive nodes skip k8s client creation entirely and only respond to `/ping`, `/healthz`, `/metrics`, and UDP echo (if enabled)
- Mode is evaluated once at pod startup via FNV-1a hash of `spec.nodeName` and never re-evaluated — passive nodes make zero k8s API calls for their entire lifetime
- `ACTIVE_NODES` provides an explicit override for small clusters where the hash alone cannot guarantee at least one active node

### Key details
- New `goldpinger_node_mode` Prometheus gauge: 1 = active, 0 = passive
- Passive nodes return 503 on `/check`, `/check_all`, `/cluster_health`
- `--check-node-hash` flag previews hash buckets without starting server
- Helm chart gains `activeNodePercentage` and `activeNodes` values
- README documents the sharding model, startup-only evaluation, and per-mode endpoint behavior

Fixes #165

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all 9 new unit tests pass (determinism, distribution, overrides, edge cases)
- [x] Deployed to a 7-node IPv6-only kubeadm cluster at `ACTIVE_NODE_PERCENTAGE=50`: 3 active, 4 passive
- [x] Active nodes ping all 7 peers including passive ones
- [x] Passive nodes: `/ping` → 200, `/check` → 503, `goldpinger_node_mode` → 0
- [x] UDP probes from active → passive nodes work correctly (passive runs UDP listener)
- [x] Rolling restart correctly re-evaluates mode assignments